### PR TITLE
Properly handle "drive" attribute as string or numeric

### DIFF
--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -509,7 +509,11 @@ void XC7Packer::check_valid_pad(CellInfo *ci, std::string type)
     auto drive_attr = ci->attrs.find(ctx->id("DRIVE"));
     // no drive strength attribute: use default
     if (drive_attr == ci->attrs.end()) return;
-    auto drive = drive_attr->second.as_int64();
+    int64_t drive;
+    if (drive_attr->second.is_string)
+        drive = std::stoi(drive_attr->second.as_string());
+    else
+        drive = drive_attr->second.as_int64();
 
     bool is_iob33 = boost::starts_with(type, "IOB33");
     if (is_iob33) {
@@ -521,8 +525,13 @@ void XC7Packer::check_valid_pad(CellInfo *ci, std::string type)
         if (iostandard != "LVCMOS12" && (drive == 12 || drive == 16)) return;
     }
 
+    std::string drive_attr_str;
+    if (drive_attr->second.is_string)
+        drive_attr_str = drive_attr->second.as_string();
+    else
+        drive_attr_str = std::to_string(drive);
     log_error("unsupported DRIVE strength property %s for port %s",
-        drive_attr->second.c_str(), ci->name.c_str(ctx));
+        drive_attr_str.c_str(), ci->name.c_str(ctx));
 }
 
 std::string XC7Packer::get_ologic_site(const std::string &io_bel)


### PR DESCRIPTION
While reading a XDC file containing a "drive" attribute, it seems the value is stored as a string, even if it's a numeric value.
Despite it's name, the "as_int64" method does not do any conversion, instead expecting it to be already stored as a numeric value. So, conversion has to be handled explicitly. 

The existing "int_or_default" function seems close, but I'm not sure what value to put as "default". Maybe zero could work.

Fixes #7 .