### PR TITLE
fix 256 bit attr error

### DIFF
--- a/common/nextpnr.cc
+++ b/common/nextpnr.cc
@@ -202,7 +202,7 @@ Property Property::from_string(const std::string &s)
     size_t cursor = s.find_first_not_of("01xz");
     if (cursor == std::string::npos) {
         // if it fits into an int64_t make it a number
-        if (s.size() <= 64) {
+        if (s.size() <= 256) {
             p.str = std::string(s.rbegin(), s.rend());
             p.is_string = false;
             p.update_intval();


### PR DESCRIPTION
the INIT_00 parameter of ramb36e1 is 256 bit, I find some error in multiple ramb36e1, it would add a space in the INIT_00. 
Maybe all parameter more than 64 bit will be affected