### PR TITLE
gui/quadtree.h: drop const on max_elems_

### DIFF
--- a/gui/quadtree.h
+++ b/gui/quadtree.h
@@ -118,7 +118,7 @@ template <typename CoordinateT, typename ElementT> class QuadTreeNode
     BoundingBox bound_;
     // How many elements should be contained in this node until it splits into
     // sub-nodes.
-    const size_t max_elems_;
+    size_t max_elems_;
     // Four sub-nodes or nullptr if it hasn't split yet.
     std::unique_ptr<QuadTreeNode<CoordinateT, ElementT>[]> children_ = nullptr;
     // Coordinates of the split.


### PR DESCRIPTION
Fixes following GCC 14 error (and similar):

```
nextpnr-xilinx/gui/quadtree.h:230:20: error: assignment of read-only member ‘nextpnr_xilinx::QuadTreeNode<CoordinateT, ElementT>::max_elems_’
  230 |         max_elems_ = other.max_elems_;
```