### PR TITLE
boost::filesystem::basename no longer exists

### DIFF
--- a/bba/main.cc
+++ b/bba/main.cc
@@ -19,7 +19,7 @@
  */
 
 #include <assert.h>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
 #include <iostream>
 #include <map>
@@ -484,7 +484,7 @@ int main(int argc, char **argv)
             fprintf(fileOut, "%s\n", s.c_str());
 
         fprintf(fileOut, "const char %s[%d] =\n", streams[0].name.c_str(), int(data.size()) + 1);
-        fprintf(fileOut, "#embed_str \"%s\"\n", boost::filesystem::basename(files.at(2)).c_str());
+        fprintf(fileOut, "#embed_str \"%s\"\n", boost::filesystem::path(files.at(2)).stem().c_str());
         fprintf(fileOut, ";\n");
 
         for (auto &s : postText)

--- a/common/command.cc
+++ b/common/command.cc
@@ -29,7 +29,7 @@
 
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/join.hpp>
-#include <boost/filesystem/convenience.hpp>
+#include <boost/filesystem/path.hpp>
 #include <boost/program_options.hpp>
 #include <fstream>
 #include <iostream>
@@ -68,14 +68,14 @@ bool CommandHandler::parseOptions()
 bool CommandHandler::executeBeforeContext()
 {
     if (vm.count("help") || argc == 1) {
-        std::cerr << boost::filesystem::basename(argv[0])
+        std::cerr << boost::filesystem::path(argv[0]).stem()
                   << " -- Next Generation Place and Route (Version " GIT_DESCRIBE_STR ")\n";
         std::cerr << options << "\n";
         return argc != 1;
     }
 
     if (vm.count("version")) {
-        std::cerr << boost::filesystem::basename(argv[0])
+        std::cerr << boost::filesystem::path(argv[0]).stem()
                   << " -- Next Generation Place and Route (Version " GIT_DESCRIBE_STR ")\n";
         return true;
     }


### PR DESCRIPTION
This API, which was deprecated, has been removed in boost-1.85.0.
The following modifications are required to support the latest boost library.