### PR TITLE
Changed boost library deprecated function in bbasm

### DIFF
--- a/bba/main.cc
+++ b/bba/main.cc
@@ -19,8 +19,8 @@
  */
 
 #include <assert.h>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/program_options.hpp>
+#include <boost/filesystem.hpp>
 #include <iostream>
 #include <map>
 #include <stdint.h>
@@ -484,7 +484,7 @@ int main(int argc, char **argv)
             fprintf(fileOut, "%s\n", s.c_str());
 
         fprintf(fileOut, "const char %s[%d] =\n", streams[0].name.c_str(), int(data.size()) + 1);
-        fprintf(fileOut, "#embed_str \"%s\"\n", boost::filesystem::basename(files.at(2)).c_str());
+        fprintf(fileOut, "#embed_str \"%s\"\n", boost::filesystem::path(files.at(2)).filename().c_str());
         fprintf(fileOut, ";\n");
 
         for (auto &s : postText)


### PR DESCRIPTION
The current version can't compile on boost 1.86 (latest on archlinux). 