### PR TITLE
Added IN_ONLY and IN_TERM.NONE for TMDS_33, enabling HDMI, tested on Spartan 7 and Zynq 7

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -950,6 +950,17 @@ struct FasmBackend
                 write_bit("SSTL12_SSTL135_SSTL15.IN");
         }
 
+        // IN_TERM.NONE and IN_ONLY for TMDS_33 output, e.g. HDMI signals
+        if (is_output && is_diff) {
+            if (is_tmds33 && yLoc == 1) {
+                if (pad->attrs.count(ctx->id("IN_TERM")))
+                    write_bit("IN_TERM." + pad->attrs.at(ctx->id("IN_TERM")).as_string());
+                else
+                    write_bit("IN_TERM.NONE");
+                write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVDS_25_LVTTL_SSTL135_SSTL15_TMDS_33.IN_ONLY");
+            }
+        }
+
         write_bit("PULLTYPE." + pulltype);
         pop(); // IOB_YN
 


### PR DESCRIPTION
Added a small segment of code in fasm.cc, fixing the HDMI designs based on ordinary TMDS output. It's confirmed to work on Spartan 7 and Zynq 7 boards. 

Somehow, Vivado will emit IN_TERM.NONE and IN_ONLY for TMDS_33 output ports. Without these, HDMI won't work. I don't have fast enough equipment to test the electric signal difference so far. 

It might be recommended to add "SLEW FAST" in the related constraints also (Vivado will do it), but 480p HDMI (DVI signals) works pretty fine without them. 