### PR TITLE
Support for cascaded OSERDESE2

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1062,7 +1062,10 @@ struct FasmBackend
             write_bit("ODDR.DDR_CLK_EDGE.SAME_EDGE");
             write_bit("ODDR.SRUSED");
             write_bit("ODDR_TDDR.IN_USE");
-            write_bit("OQUSED", get_net_or_empty(ci, ctx->id("OQ")) != nullptr);
+            // For slave OSERDESE2, OQUSED must be set even though OQ is not connected
+            std::string serdes_mode = str_or_default(ci->params, ctx->id("SERDES_MODE"), "MASTER");
+            bool is_slave = (serdes_mode == "SLAVE");
+            write_bit("OQUSED", is_slave || (get_net_or_empty(ci, ctx->id("OQ")) != nullptr));
             write_bit("ZINV_CLK", !bool_or_default(ci->params, ctx->id("IS_CLK_INVERTED"), false));
             for (std::string t : {"T1", "T2", "T3", "T4"})
                 write_bit("ZINV_" + t, (get_net_or_empty(ci, ctx->id(t)) != nullptr || t == "T1") &&
@@ -1102,6 +1105,8 @@ struct FasmBackend
 #endif
             write_bit("SRTYPE.SYNC");
             write_bit("TSRTYPE.SYNC");
+            if (is_slave) write_bit("SERDES_MODE.SLAVE");
+
             pop();
         } else if (ci->type == ctx->id("ISERDESE2_ISERDESE2")) {
             std::string data_rate = str_or_default(ci->params, ctx->id("DATA_RATE"));

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -855,8 +855,8 @@ void XC7Packer::pack_iologic()
                         auto slave_bel_name = parts.front() + "Y" + std::to_string(y_coord_slave) + "/OSERDESE2";
 
                         CellInfo *slave_cell;
-                        if (shiftin1 != nullptr) slave_cell = shiftin1->users.front().cell;
-                        else slave_cell = shiftin2->users.front().cell;
+                        if (shiftin1 != nullptr) slave_cell = shiftin1->driver.cell;
+                        else slave_cell = shiftin2->driver.cell;
                         slave_cell->attrs[id_BEL] = slave_bel_name;
                         used_oserdes_bels.insert(ctx->getBelByName(ctx->id(slave_bel_name)));
                     }


### PR DESCRIPTION
This should solve https://github.com/openXC7/nextpnr-xilinx/issues/76, https://github.com/openXC7/nextpnr-xilinx/issues/70, and where this is found https://github.com/chili-chips-ba/openeye-CamSI/issues/42. 

The SHIFTIN-SHIFTOUT connection was inverted, and fixing it passes the PnR. 

Then, two FASM options, OSERDES.SERDES_MODE.SLAVE and OQUSED on slave, are found to be related to correct hardware operation. 

A 720p HDMI design using OSERDESE2 at 74.25 MHz pixel clock (5x serdes clock, 10x output data rate) has been confirmed to work with OpenXC7, on the Spartan 7 [booelan board](https://www.realdigital.org/hardware/boolean). 

As a basic regression test, the UberDDR3 (which uses OSERDES) main branch still works on Artix 7, Nexys Video. 

Patch to prjxray-db https://github.com/openXC7/prjxray-db/commit/381966a746cb4cf4a7f854f0e53caa3bf74fbe62 includes the required db entries for Artix 7, and similar entries for Spartan/Zynq/Kintex 7 would also be helpful. I've run the Spartan 7 one locally, and will run for other series and PR to prjxray-db when that's ready. 