### PR TITLE
frontend: keep net merge history for imported nets

### DIFF
--- a/frontend/frontend_base.h
+++ b/frontend/frontend_base.h
@@ -342,6 +342,7 @@ template <typename FrontendType> struct GenericFrontend
             // Add to the flat index of nets
             net->udata = int(net_flatindex.size());
             net_flatindex.push_back(net);
+            net_old_indices.emplace_back();
             // Add to the module-level index of netsd
             midx = net->udata;
             // Create aliases for all possible names
@@ -511,6 +512,7 @@ template <typename FrontendType> struct GenericFrontend
                                                         impl.get_vector_bit_constval(bits, i));
                     cnet->udata = int(net_flatindex.size());
                     net_flatindex.push_back(cnet);
+                    net_old_indices.emplace_back();
                     net_ref = cnet->udata;
                 } else {
                     // Otherwise, lookup (creating if needed) the net with given in-module index


### PR DESCRIPTION
Fix a frontend bookkeeping bug during JSON import.

  Imported nets are appended to `net_flatindex`, but the corresponding  `net_old_indices` entry was not created in:
  - `create_or_get_net(...)`
  - the imported constant-net path in `import_submodule_cell(...)`

  Later, `merge_nets()` indexes `net_old_indices` by flat net index, so this can cause an out-of-range access during import.

  This patch extends `net_old_indices` when a new imported net is pushed into `net_flatindex`, keeping the merge bookkeeping consistent.

Tested by rebuilding `nextpnr-xilinx` and confirming that this removes the frontend `std::out_of_range` crash on the failing JSON import path.