### PR TITLE
Fix build with Boost 1.90+ and C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(item ${ARCH})
     endif()
 endforeach()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 if (MSVC)
     set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "" FORCE)
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /D_DEBUG /W4 /wd4100 /wd4244 /wd4125 /wd4800 /wd4456 /wd4458 /wd4305 /wd4459 /wd4121 /wd4996")
@@ -99,7 +99,7 @@ endif()
 find_package(Sanitizers)
 
 # List of Boost libraries to include
-set(boost_libs filesystem thread program_options iostreams system)
+set(boost_libs filesystem thread program_options iostreams)
 
 if (BUILD_GUI AND NOT BUILD_PYTHON)
     message(FATAL_ERROR "GUI requires Python to build")

--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -43,6 +43,8 @@
 #include <fstream>
 #include <numeric>
 #include <queue>
+#include <random>
+#include <limits>
 #include <tuple>
 #include <unordered_map>
 #include "log.h"
@@ -528,7 +530,7 @@ class HeAPPlacer
             available_bels[ctx->getBelType(bel)].push_back(bel);
         }
         for (auto &t : available_bels) {
-            std::random_shuffle(t.second.begin(), t.second.end(), [&](size_t n) { return ctx->rng(int(n)); });
+            std::shuffle(t.second.begin(), t.second.end(), std::default_random_engine(ctx->rng(std::numeric_limits<int>::max())));
         }
         for (auto cell : sorted(ctx->cells)) {
             CellInfo *ci = cell.second;


### PR DESCRIPTION
## Problem

nextpnr-xilinx fails to build on systems with Boost 1.90+ and/or when using C++17:

- **Boost 1.90** made `Boost::system` header-only, so CMake fails when trying to find it as a linkable library.
- **Eigen 3.4+** requires C++14 or later, but `CMAKE_CXX_STANDARD` is set to 11.
- **C++17** removes `std::random_shuffle`, causing a compile error in `placer_heap.cc`.

## Changes

- `CMakeLists.txt`: Bump `CMAKE_CXX_STANDARD` from 11 to 17
- `CMakeLists.txt`: Remove `system` from `boost_libs` (header-only since Boost 1.90)
- `common/placer_heap.cc`: Replace `std::random_shuffle` with `std::shuffle` + add missing includes

## Tested on

- macOS 15.3 ARM64 (Apple Silicon M2)
- Boost 1.90.0, Eigen 3.4, Homebrew LLVM 17
- Built with `-DARCH=xilinx -DBUILD_GUI=OFF -DBUILD_PYTHON=OFF -DUSE_OPENMP=OFF`
- Successfully synthesized, placed, routed, and programmed a Basys 3