### PR TITLE
Fix build with recent GNU/Linux & compiler

### DIFF
--- a/3rdparty/json11/json11.cpp
+++ b/3rdparty/json11/json11.cpp
@@ -25,6 +25,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <climits>
+#include <cstdint>
 #include <cerrno>
 
 namespace json11 {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(nextpnr CXX C)
 
 option(BUILD_GUI "Build GUI" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,7 +177,7 @@ if (BUILD_PYTHON)
     endwhile ()
 
     if (NOT Boost_PYTHON_FOUND)
-        foreach (PyVer 3 36 37 38 39 310 311 312)
+        foreach (PyVer 3 36 37 38 39 310 311 312 313 314)
             find_package(Boost QUIET COMPONENTS python${PyVer} ${boost_libs})
             if ("${Boost_LIBRARIES}" MATCHES ".*(python|PYTHON).*" )
                 set(Boost_PYTHON_FOUND TRUE)


### PR DESCRIPTION
This PR adds some fixes to allows build with recent OS:

- first commit fix `cmake_minimum_version` to avoid futur error and to removes warning:
  ```
   CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
     Compatibility with CMake < 3.10 will be removed from a future version of
     CMake.

     Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
     to tell CMake that the project requires at least <min> but has been updated
    to work with policies introduced by <max> or earlier.
   ```
- 2nd commit fix detection with OS where python 3.13 or 3.14 is installed
- 3rd commit fix error due to missing cstdint header:
  ```
  /somewhere/nextpnr-xilinx/3rdparty/json11/json11.cpp:96:32: error: ‘uint8_t’ does not name a type                
      96 |         } else if (static_cast<uint8_t>(ch) <= 0x1f) {                                                                                                 
         |                                ^~~~~~~                                                                                                                 
   /somewhere/nextpnr-xilinx/3rdparty/json11/json11.cpp:28:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
      27 | #include <climits>
     +++ |+#include <cstdint>
      28 | #include <cerrno>
   ```

Side note: This PR has been tested with #84 applied.
