### PR TITLE
fix: python SyntaxWarning with unescaped regex

### DIFF
--- a/xilinx/python/xilinx_device.py
+++ b/xilinx/python/xilinx_device.py
@@ -452,7 +452,7 @@ def import_device(name, prjxray_root, metadata_root):
 		return ij["intents"][str(ij["tiles"][tiletype][wirename])]
 
 	d = Device(name)
-	match = re.search("^(xc7[sakz]\d+t?)\w+-\d", name)
+	match = re.search(r"^(xc7[sakz]\d+t?)\w+-\d", name)
 	if not match:
 		raise RuntimeError("{} is not known device name".format(name))
 	fabricname = match.groups()[0]


### PR DESCRIPTION
Fixes a warning that appears when this script gets run.

This fix is important, because a future Python version (maybe 3.14 or 3.15 iirc) turns this SyntaxWarning into an error. Easy fix to get ahead of.