### PR TITLE
GTX channel driven by IBUFDS (CPLL mode) support, with PCIe working on Kintex 7

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2075,6 +2075,7 @@ struct FasmBackend
 
     void write_ibufds_gte2(CellInfo * ci)
     {
+        push(get_tile_name(ci->bel.tile));
         Loc siteLoc = ctx->getSiteLocInTile(ci->bel);
         push("IBUFDS_GTE2_Y" + std::to_string(siteLoc.y));
         write_bit("IN_USE");
@@ -2086,7 +2087,7 @@ struct FasmBackend
         if (!clkrcv_trst) log_warning("%s/%s: According to ug482, CLKRCV_TRST should always be on\n",
                                        ci->hierpath.c_str(ctx), ci->name.c_str(ctx));
         write_bit("CLKRCV_TRST", clkrcv_trst);
-        pop();
+        pop(2);
     }
 
     void write_gtp_pll(CellInfo *ci)
@@ -2747,7 +2748,7 @@ struct FasmBackend
     void write_pcie_2_1(CellInfo *ci)
     {
         push(get_tile_name(ci->bel.tile));
-        push("PCIE_2_1");
+        push("PCIE");
 
         auto write_str_bool = [&](std::string attribute, std::string deflt = "FALSE") {
             auto val = str_or_default(ci->params, ctx->id(attribute), deflt);
@@ -3665,14 +3666,17 @@ void write_gtx_channel(CellInfo *ci)
         write_inv("TXUSRCLK2");
         write_inv("RXUSRCLK2");
         write_inv("TXUSRCLK2");
+        write_inv("CPLLLOCKDETCLK");
+        write_bit("GTREFCLK0_USED", bool_or_default(ci->params, ctx->id("_GTREFCLK0_USED"), false));
+        write_bit("GTREFCLK1_USED", bool_or_default(ci->params, ctx->id("_GTREFCLK1_USED"), false));
 
         auto outrefclk_sel_inv = int_or_default(ci->params, ctx->id("OUTREFCLK_SEL_INV"), 0b10);
         write_int_vector("OUTREFCLK_SEL_INV[1:0]", outrefclk_sel_inv, 2);
 
         write_str_bool("PCS_PCIE_EN", "PCS_PCIE_EN");
 
-        auto rsvd_attr = int_or_default(ci->params, ctx->id("RSVD_ATTR"), 0);
-        write_int_vector("RSVD_ATTR[47:0]", rsvd_attr, 48);
+        auto rsvd_attr = int_or_default(ci->params, ctx->id("PCS_RSVD_ATTR"), 0);
+        write_int_vector("PCS_RSVD_ATTR[47:0]", rsvd_attr, 48);
 
         auto pd_trans_time_from_p2 = int_or_default(ci->params, ctx->id("PD_TRANS_TIME_FROM_P2"), 0);
         write_int_vector("PD_TRANS_TIME_FROM_P2[11:0]", pd_trans_time_from_p2, 12);
@@ -3717,6 +3721,8 @@ void write_gtx_channel(CellInfo *ci)
                 log_error("Invalid RX_DATA_WIDTH parameter '%d' for GTXE2_CHANNEL instance %s\n", rx_data_width, ci->name.c_str(ctx));
         }
         write_int_vector("RX_DATA_WIDTH[2:0]", rx_data_width, 3);
+        auto rx_int_datawidth = bool_or_default(ci->params, ctx->id("RX_INT_DATAWIDTH"), false);
+        write_bit("RX_INT_DATAWIDTH[0]", rx_int_datawidth);
         auto rx_ddi_sel = int_or_default(ci->params, ctx->id("RX_DDI_SEL"), 0);
         write_int_vector("RX_DDI_SEL[5:0]", rx_ddi_sel, 6);
         auto rx_debug_cfg = int_or_default(ci->params, ctx->id("RX_DEBUG_CFG"), 0);
@@ -3740,10 +3746,14 @@ void write_gtx_channel(CellInfo *ci)
         write_int_vector("RX_DFE_KL_CFG2[31:0]", rx_dfe_kl_cfg2, 32);
         auto rx_dfe_lpm_cfg = int_or_default(ci->params, ctx->id("RX_DFE_LPM_CFG"), 0b100101010100);
         write_int_vector("RX_DFE_LPM_CFG[11:0]", rx_dfe_lpm_cfg, 12);
+        auto rx_dfe_lpm_hold_during_eidle = bool_or_default(ci->params, ctx->id("RX_DFE_LPM_HOLD_DURING_EIDLE"), false);
+        write_bit("RX_DFE_LPM_HOLD_DURING_EIDLE[0]", rx_dfe_lpm_hold_during_eidle);
         auto rx_dfe_ut_cfg = int_or_default(ci->params, ctx->id("RX_DFE_UT_CFG"), 0x11E00);
         write_int_vector("RX_DFE_UT_CFG[16:0]", rx_dfe_ut_cfg, 17);
         auto rx_dfe_vp_cfg = int_or_default(ci->params, ctx->id("RX_DFE_VP_CFG"), 0x03F03);
         write_int_vector("RX_DFE_VP_CFG[16:0]", rx_dfe_vp_cfg, 17);
+        auto rx_dfe_xyd_cfg = int_or_default(ci->params, ctx->id("RX_DFE_XYD_CFG"), 0);
+        write_int_vector("RX_DFE_XYD_CFG[12:0]", rx_dfe_xyd_cfg, 13);
 
         write_str_bool("RX_DISPERR_SEQ_MATCH", "RX_DISPERR_SEQ_MATCH");
         auto rx_os_cfg = int_or_default(ci->params, ctx->id("RX_OS_CFG"), 0);
@@ -3907,6 +3917,8 @@ void write_gtx_channel(CellInfo *ci)
                 log_error("Invalid TX_DATA_WIDTH parameter '%d' for GTXE2_CHANNEL instance %s\n", tx_data_width, ci->name.c_str(ctx));
         }
         write_int_vector("TX_DATA_WIDTH[2:0]", tx_data_width, 3);
+        auto tx_int_datawidth = bool_or_default(ci->params, ctx->id("TX_INT_DATAWIDTH"), false);
+        write_bit("TX_INT_DATAWIDTH[0]", tx_int_datawidth);
 
         auto tx_drive_mode = str_or_default(ci->params, ctx->id("TX_DRIVE_MODE"), "DIRECT");
         if (tx_drive_mode != "DIRECT" && tx_drive_mode != "PIPE" && tx_drive_mode != "PIPEGEN3")
@@ -3985,10 +3997,13 @@ void write_gtx_channel(CellInfo *ci)
         auto txpmareset_time = int_or_default(ci->params, ctx->id("TXPMARESET_TIME"), 0);
         write_int_vector("TXPMARESET_TIME[4:0]", txpmareset_time, 5);
 
+        auto tx_qpi_status_en = bool_or_default(ci->params, ctx->id("TX_QPI_STATUS_EN"), false);
+        write_bit("TX_QPI_STATUS_EN[0]", tx_qpi_status_en);
+
         auto ucodeer_clr = bool_or_default(ci->params, ctx->id("UCODEER_CLR"), false);
         write_bit("UCODEER_CLR[0]", ucodeer_clr);
 
-        pop(); // GTPE2_CHANNEL
+        pop(); // GTXE2_CHANNEL
         pop(); // tile name
     }
 

--- a/xilinx/pack_gt_xc7.cc
+++ b/xilinx/pack_gt_xc7.cc
@@ -241,39 +241,46 @@ void XC7Packer::pack_gt()
             fold_inverter(ci, "TXUSRCLK");
             fold_inverter(ci, "TXUSRCLK2");
 
-            for (auto &port : ci->ports) {
-                auto port_name = port.first.str(ctx);
-                auto net = get_net_or_empty(ci, port.first);
+            {
+                // Collect bracket-named ports before the loop to avoid iterator
+                // invalidation when rename_port erases+inserts into ci->ports.
+                std::vector<std::pair<IdString,IdString>> to_rename;
+                for (auto &port : ci->ports) {
+                    auto port_name = port.first.str(ctx);
+                    auto net = get_net_or_empty(ci, port.first);
 
-                // If one of the clock ports is tied, then Vivado just disconnects them
-                if (net != nullptr && (boost::starts_with(port_name, "PLL") && boost::ends_with(port_name, "CLK"))
-                                && !boost::contains(port_name, "CLKMONITOR")) {
-                    if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
+                    // If one of the clock ports is tied, then Vivado just disconnects them
+                    if (net != nullptr && (boost::starts_with(port_name, "PLL") && boost::ends_with(port_name, "CLK"))
+                                    && !boost::contains(port_name, "CLKMONITOR")) {
+                        if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
+                            disconnect_port(ctx, ci, port.first);
+                            continue;
+                        }
+                        auto driver = net->driver.cell;
+                        if (driver->type != id_GTPE2_COMMON)
+                            log_error("The clock port '%s' of the GTPE2_CHANNEL instance %s can only be driven "
+                                        "by the clock ouputs of a GTPE2_COMMON instance, but not %s\n",
+                                        port_name.c_str(), ci->name.c_str(ctx), driver->type.c_str(ctx));
+                        auto drv_port = net->driver.port.str(ctx);
+                        auto port_prefix = port_name.substr(0, 4);
+                        auto port_suffix = port_name.substr(4);
+                        if (!boost::starts_with(drv_port, port_prefix) || !boost::ends_with(drv_port, port_suffix))
+                            log_error("The port %s of a GTPE2_CHANNEL instance can only be connected to the port %sOUT%s "
+                                        "of a GTPE2_COMMON instance, but not to %s.\n", port_name.c_str(), port_prefix.c_str(), port_suffix.c_str(),
+                                        drv_port.c_str());
+                        // These ports are hardwired. Disconnect
                         disconnect_port(ctx, ci, port.first);
-                        continue;
                     }
-                    auto driver = net->driver.cell;
-                    if (driver->type != id_GTPE2_COMMON)
-                        log_error("The clock port '%s' of the GTPE2_CHANNEL instance %s can only be driven "
-                                    "by the clock ouputs of a GTPE2_COMMON instance, but not %s\n",
-                                    port_name.c_str(), ci->name.c_str(ctx), driver->type.c_str(ctx));
-                    auto drv_port = net->driver.port.str(ctx);
-                    auto port_prefix = port_name.substr(0, 4);
-                    auto port_suffix = port_name.substr(4);
-                    if (!boost::starts_with(drv_port, port_prefix) || !boost::ends_with(drv_port, port_suffix))
-                        log_error("The port %s of a GTPE2_CHANNEL instance can only be connected to the port %sOUT%s "
-                                    "of a GTPE2_COMMON instance, but not to %s.\n", port_name.c_str(), port_prefix.c_str(), port_suffix.c_str(),
-                                    drv_port.c_str());
-                    // These ports are hardwired. Disconnect
-                    disconnect_port(ctx, ci, port.first);
-                }
 
-                if (boost::contains(port_name, "[") && boost::contains(port_name, "]")) {
-                    auto new_port_name = std::string(port_name);
-                    boost::replace_all(new_port_name, "[", "");
-                    boost::replace_all(new_port_name, "]", "");
-                    rename_port(ctx, ci, ctx->id(port_name), ctx->id(new_port_name));
+                    if (boost::contains(port_name, "[") && boost::contains(port_name, "]")) {
+                        auto new_port_name = std::string(port_name);
+                        boost::replace_all(new_port_name, "[", "");
+                        boost::replace_all(new_port_name, "]", "");
+                        to_rename.emplace_back(ctx->id(port_name), ctx->id(new_port_name));
+                    }
                 }
+                for (auto &pr : to_rename)
+                    rename_port(ctx, ci, pr.first, pr.second);
             }
         } else if (ci->type == id_GTXE2_CHANNEL) {
             fold_inverter(ci, "CLKRSVD0");
@@ -297,43 +304,59 @@ void XC7Packer::pack_gt()
             fold_inverter(ci, "TXUSRCLK");
             fold_inverter(ci, "TXUSRCLK2");
 
-            for (auto &port : ci->ports) {
-                auto port_name = port.first.str(ctx);
-                auto net = get_net_or_empty(ci, port.first);
+            {
+                std::vector<std::pair<IdString,IdString>> to_rename;
+                for (auto &port : ci->ports) {
+                    auto port_name = port.first.str(ctx);
+                    auto net = get_net_or_empty(ci, port.first);
 
-                // If one of the clock ports is tied, then Vivado just disconnects them
-                if (net != nullptr && ((boost::starts_with(port_name, "PLL") && boost::ends_with(port_name, "CLK")) ||
-                                       boost::contains(port_name, "REFCLK")) &&
-                                       !boost::contains(port_name, "CLKMONITOR") &&
-                                       !boost::contains(port_name, "CLKLOST")) {
-                    if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
+                    // If one of the clock ports is tied, then Vivado just disconnects them
+                    if (net != nullptr && ((boost::starts_with(port_name, "PLL") && boost::ends_with(port_name, "CLK")) ||
+                                           boost::contains(port_name, "REFCLK") ||
+                                           boost::starts_with(port_name, "QPLL")) &&
+                                           !boost::contains(port_name, "CLKMONITOR") &&
+                                           !boost::contains(port_name, "CLKLOST")) {
+                        if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET")) {
+                            disconnect_port(ctx, ci, port.first);
+                            continue;
+                        }
+                        auto driver = net->driver.cell;
+                        // GTX CPLL mode is possible: GTXE2_CHANNEL.GTREFCLK* driven directly by IBUFDS_GTE2
+                        // (no GTXE2_COMMON required in the design)
+                        if (driver->type != id_GTXE2_COMMON && driver->type !=id_IBUFDS_GTE2)
+                            log_error("The clock port '%s' of the GTXE2_CHANNEL instance %s can only be driven "
+                                        "by the clock ouputs of a GTXE2_COMMON or IBUFDS_GTE2 instance, but not %s\n",
+                                        port_name.c_str(), ci->name.c_str(ctx), driver->type.c_str(ctx));
+                        auto drv_port = net->driver.port.str(ctx);
+                        auto port_prefix = port_name.substr(0, 4);
+                        auto port_suffix = port_name.substr(4);
+                        if (drv_port != "O" && (!boost::starts_with(drv_port, port_prefix) || !boost::ends_with(drv_port, port_suffix)))
+                            log_warning("The port %s of a GTXE2_CHANNEL instance can only be connected to the port %sOUT%s "
+                                        "of a GTXE2_COMMON instance, or IBUFDS_GTE2, but not to %s.\n",
+                                        port_name.c_str(), port_prefix.c_str(), port_suffix.c_str(), drv_port.c_str());
+                        // GTX CPLL mode: GTREFCLk0/1 treatment similar to GTXE2_COMMON
+                        bool used = net->name != ctx->id("$PACKER_VCC_NET") &&
+                                    net->name != ctx->id("$PACKER_GND_NET");
+                        if (used && port_name == "GTREFCLK0")
+                            ci->setParam(ctx->id("_GTREFCLK0_USED"), Property(1, 1));
+                        if (used && port_name == "GTREFCLK1")
+                            ci->setParam(ctx->id("_GTREFCLK1_USED"), Property(1, 1));
+                        // These ports are hardwired. Disconnect
                         disconnect_port(ctx, ci, port.first);
-                        continue;
                     }
-                    auto driver = net->driver.cell;
-                    if (driver->type != id_GTXE2_COMMON)
-                        log_error("The clock port '%s' of the GTXE2_CHANNEL instance %s can only be driven "
-                                    "by the clock ouputs of a GTXE2_COMMON instance, but not %s\n",
-                                    port_name.c_str(), ci->name.c_str(ctx), driver->type.c_str(ctx));
-                    auto drv_port = net->driver.port.str(ctx);
-                    auto port_prefix = port_name.substr(0, 4);
-                    auto port_suffix = port_name.substr(4);
-                    if (!boost::starts_with(drv_port, port_prefix) || !boost::ends_with(drv_port, port_suffix))
-                        log_error("The port %s of a GTXE2_CHANNEL instance can only be connected to the port %sOUT%s "
-                                    "of a GTXE2_COMMON instance, but not to %s.\n", port_name.c_str(), port_prefix.c_str(), port_suffix.c_str(),
-                                    drv_port.c_str());
-                    // These ports are hardwired. Disconnect
-                    disconnect_port(ctx, ci, port.first);
-                }
 
-                if (boost::contains(port_name, "[") && boost::contains(port_name, "]")) {
-                    auto new_port_name = std::string(port_name);
-                    boost::replace_all(new_port_name, "[", "");
-                    boost::replace_all(new_port_name, "]", "");
-                    rename_port(ctx, ci, ctx->id(port_name), ctx->id(new_port_name));
+                    if (boost::contains(port_name, "[") && boost::contains(port_name, "]")) {
+                        auto new_port_name = std::string(port_name);
+                        boost::replace_all(new_port_name, "[", "");
+                        boost::replace_all(new_port_name, "]", "");
+                        to_rename.emplace_back(ctx->id(port_name), ctx->id(new_port_name));
+                    }
                 }
+                for (auto &pr : to_rename)
+                    rename_port(ctx, ci, pr.first, pr.second);
             }
-        }    }
+        }    
+    }
 }
 
 NEXTPNR_NAMESPACE_END

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -367,16 +367,26 @@ void XC7Packer::pack_io()
         if (buf_cell->type == ctx->id("IBUFDS_GTE2")) {
             constrain_ibufds_gt_site(buf_cell, pad_cell->attrs[id_BEL].as_string());
             auto net = buf_cell->ports[ctx->id("O")].net;
-            if (net != nullptr && net->users.size() == 1) {
-                auto user_cell = net->users[0].cell;
-                auto is_gtp = user_cell->type == id_GTPE2_COMMON;
-                auto is_gtx = user_cell->type == id_GTXE2_COMMON;
-                if (!(is_gtp || is_gtx))
-                    log_error("IBUFDS_GTE2 instance %s output port must be connected to a GTPE2_COMMON or GTXE2_COMMON instance, but is instead connected to an instance %s of type %s\n",
-                        buf_cell->name.c_str(ctx), user_cell->name.c_str(ctx), user_cell->type.c_str(ctx));
-                constrain_gt(pad_cell, user_cell);
+            if (net == nullptr)
+                log_error("IBUFDS_GTE2 instance %s output port is not connected\n", buf_cell->name.c_str(ctx));
+            // Scan users of IBUFDS_GTE2.O
+            CellInfo *gt_common = nullptr;
+            bool has_gtxe2_channel_direct = false;
+            for (auto &usr : net->users) {
+                if (usr.cell->type == id_GTPE2_COMMON || usr.cell->type == id_GTXE2_COMMON)
+                    gt_common = usr.cell;
+                else if (usr.cell->type == id_GTXE2_CHANNEL)
+                    has_gtxe2_channel_direct = true;
+            }
+            if (gt_common) {
+                constrain_gt(pad_cell, gt_common);
                 continue;
-            } else log_error("IBUFDS_GTE2 instance %s output port is not connected, or connected to multiple cells\n", buf_cell->name.c_str(ctx));
+            }
+            // GTX CPLL mode: GTXE2_CHANNEL already directly connected (second pad pass).
+            if (has_gtxe2_channel_direct)
+                continue;
+            log_error("IBUFDS_GTE2 instance %s output port must be connected to a GTPE2_COMMON, GTXE2_COMMON, or GTXE2_CHANNEL instance\n",
+                buf_cell->name.c_str(ctx));
         }
 
         // This OBUF is integrated into the GTP/GTX channel pad and does not need placing


### PR DESCRIPTION
This include several fixes:

Write_ibufds_gte2 fix during fasm to bitstream. 

PCIE_2_1 to PCIE rename to avoid manually patching prjxray-db entries during fasm to bitstream. 

GTREFCLK0/1 bit handling in GTX channel, and other parameter additions (most has no influence in current usage). 

In pack_gt_xc7, the original rename_port with interfere with the for loop traverse, leaving some entries like RXDATA[2] unchanged, instead of begin changed to RXDATA2. This is required for both GTP and GTX channel. 

In pack_gt_xc7 and pack_io_xc7, allow IBUFDS_GTE2 clock output to drive GTXE2_CHANNEL, without the usage of GTXE2_COMMON. This is required for PCIe Gen1/Gen2 operation. GTXE2_CHANNEL (QPLL mode) seems unable to give a low bit rate like 5 Gbps that works with PCIe. 

This should also fix the problems mentioned in https://github.com/fpgas-online/fpgas.online-test-designs/issues/1 and https://github.com/chili-chips-ba/openPCIE/issues/14

Prjxray-db and prjxray are also changed to make GTX work with PCIe, and patches will be send separately. 