### PR TITLE
DSP: disconnect MULTSIGNIN and CARRYCASCIN tied to GND

### DIFF
--- a/xilinx/pack_dsp_xc7.cc
+++ b/xilinx/pack_dsp_xc7.cc
@@ -111,7 +111,7 @@ void XC7Packer::pack_dsps()
             for (auto &port : ci->ports) {
                 std::string n = port.first.str(ctx);
 
-                if (boost::starts_with(n, "ACIN") || boost::starts_with(n, "BCIN") || boost::starts_with(n, "PCIN")) {
+                if (boost::starts_with(n, "ACIN") || boost::starts_with(n, "BCIN") || boost::starts_with(n, "PCIN") || boost::starts_with(n, "CARRYCASCIN") || boost::starts_with(n, "MULTSIGNIN")) {
                     if (port.second.net == nullptr)
                         continue;
                     if (port.second.net->name == ctx->id("$PACKER_GND_NET"))


### PR DESCRIPTION
This fixes https://github.com/openXC7/nextpnr-xilinx/issues/64 as tested by @juanschroeder . 