### PR TITLE
xilinx: emit BRAM36 width features for RAMB36E1 odd port widths

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1493,6 +1493,21 @@ struct FasmBackend
         }
         pop();
         if (half == 0) {
+            // A RAMB36E1 expresses its port widths through the two underlying
+            // RAMB18 halves, each carrying half the data.  Widths 1 and 9 are
+            // odd and cannot be split evenly: prjxray encodes the leftover bit
+            // (for width 9 that bit is the parity bit) with a RAMB36-scope
+            // feature.  Without it the block silently behaves as width 8, and
+            // every DIP/DOP bit reads back as 0.
+            if (ci != nullptr && ci->type == id_RAMB36E1_RAMB36E1) {
+                push("RAMB36");
+                for (auto pname : {"READ_WIDTH_A", "READ_WIDTH_B", "WRITE_WIDTH_A", "WRITE_WIDTH_B"}) {
+                    int w = int_or_default(ci->params, ctx->id(pname), 0);
+                    if (w == 1 || w == 9)
+                        write_bit(std::string("BRAM36_") + pname + "_1");
+                }
+                pop();
+            }
             auto used_rdaddrcasc = used_wires_starting_with(tile, "BRAM_CASCOUT_ADDRARDADDR", false);
             auto used_wraddrcasc = used_wires_starting_with(tile, "BRAM_CASCOUT_ADDRBWRADDR", false);
             write_bit("CASCOUT_ARD_ACTIVE", !used_rdaddrcasc.empty());


### PR DESCRIPTION
`write_bram_half()` never emitted the RAMB36 scope feature that prjxray requires for RAMB36E1 port widths 1 and 9, so a width 9 port was configured as width 8 and its parity bits read back 0 on hardware. The change writes `RAMB36.BRAM36_<param>_1` for each width parameter equal to 1 or 9, at tile scope next to the CASCOUT features. RAMB18E1 is excluded by the type test, since width 9 on a RAMB18 is a native RAMB18 feature.

Validated on an xc7a35tcpg236-1. A design with 30 width 9 RAMB36E1 that corrupts every parity bit without the change works correctly with it, and the frame diff against a hand patched known good bitstream matches exactly (60 bits, segbits 27_180 and 27_181, nothing else). Regression designs with RAMB36 at widths 18 and 36 plus a RAMB18E1 at width 9 produce byte identical FASM, and a RAMB36 width 1 design gains its two features as specified.

Fixes #94.
