### PR TITLE
xc7 fixes: 0.9.x counter routing regression, global const node (#38/#41), post-route timing walk, DSP48E1 timing, mingw portability

### DIFF
--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -877,6 +877,11 @@ struct Context : Arch, DeterministicRNG
     // provided by sdf.cc
     void writeSDF(std::ostream &out, bool cvc_mode = false) const;
 
+    // provided by timing.cc; computes timing on the current (routed) design
+    // and returns per-clock fmax/target as a JSON string. Exposed to Python
+    // for --post-route report scripts (the fork lacks mainline's --report).
+    std::string reportClockFmaxJson();
+
     // --------------------------------------------------------------
 
     uint32_t checksum() const;

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -28,10 +28,10 @@
 
 #include "router2.h"
 #include <algorithm>
-#include <boost/container/flat_map.hpp>
 #include <chrono>
 #include <deque>
 #include <fstream>
+#include <map>
 #include <queue>
 #include <thread>
 #include "log.h"
@@ -81,7 +81,7 @@ struct Router2
         // nextpnr
         WireId w;
         // net --> number of arcs; driving pip
-        boost::container::flat_map<int, std::pair<int, PipId>> bound_nets;
+        std::map<int, std::pair<int, PipId>> bound_nets;
         // Historical congestion cost
         float hist_cong_cost = 1.0;
         // Wire is unavailable as locked to another arc

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -20,6 +20,7 @@
 
 #include "timing.h"
 #include <algorithm>
+#include <cstdio>
 #include <boost/range/adaptor/reversed.hpp>
 #include <deque>
 #include <map>
@@ -715,6 +716,57 @@ void assign_budget(Context *ctx, bool quiet)
 
     if (!quiet)
         log_info("Checksum: 0x%08x\n", ctx->checksum());
+}
+
+std::string Context::reportClockFmaxJson()
+{
+    Context *ctx = this;
+    std::map<IdString, double> clock_fmax;
+    try {
+        CriticalPathMap crit_paths;
+        Timing timing(ctx, true /* net_delays */, false /* update */, &crit_paths, nullptr);
+        timing.walk_paths();
+
+        for (auto &path : crit_paths) {
+            const ClockEvent &a = path.first.start;
+            const ClockEvent &b = path.first.end;
+            if (a.clock != b.clock || a.clock == ctx->id("$async$"))
+                continue;
+            double Fmax;
+            if (a.edge == b.edge)
+                Fmax = 1000 / ctx->getDelayNS(path.second.path_delay);
+            else
+                Fmax = 500 / ctx->getDelayNS(path.second.path_delay);
+            if (!clock_fmax.count(a.clock) || Fmax < clock_fmax.at(a.clock))
+                clock_fmax[a.clock] = Fmax;
+        }
+    } catch (log_execution_error_exception &) {
+        // the timing walk can log_error (combinatorial loops, incomplete
+        // timing ports, ...); a failed REPORT must not kill an already
+        // successfully routed flow -> report no clocks instead
+        return "{}";
+    }
+
+    std::string json = "{";
+    bool first = true;
+    for (auto &clock : clock_fmax) {
+        float target = ctx->setting<float>("target_freq") / 1e6;
+        auto ni = ctx->nets.find(clock.first);
+        if (ni != ctx->nets.end() && ni->second->clkconstr)
+            target = 1000 / ctx->getDelayNS(ni->second->clkconstr->period.minDelay());
+        json += first ? "\"" : ", \"";
+        for (char c : clock.first.str(ctx)) {
+            if (c == '"' || c == '\\')
+                json += '\\';
+            json += c;
+        }
+        char buf[80];
+        snprintf(buf, sizeof(buf), "\": {\"achieved\": %.2f, \"constraint\": %.2f}", clock.second, target);
+        json += buf;
+        first = false;
+    }
+    json += "}";
+    return json;
 }
 
 void timing_analysis(Context *ctx, bool print_histogram, bool print_fmax, bool print_path, bool warn_on_failure)

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -176,6 +176,15 @@ struct Timing
                     // Otherwise, for all driven input ports on this cell, if a timing arc exists between the input and
                     // the current output port, increment fanin counter
                     for (auto i : input_ports) {
+                        // A cell input pin can end up bound to the cell's own
+                        // output net (e.g. the xc7 post-route LUT pin fixup
+                        // when the router feeds the output back through an
+                        // unused input pin of the same site). Such an arc can
+                        // never be a real timing path, but counting it here
+                        // deadlocks the topological sort below as a false
+                        // combinational loop.
+                        if (cell.second->ports.at(i).net == o->net)
+                            continue;
                         DelayInfo comb_delay;
                         bool is_path = ctx->getCellDelay(cell.second.get(), i, o->name, comb_delay);
                         if (is_path)
@@ -222,6 +231,11 @@ struct Timing
                     // Skip if this is a clocked output (but allow non-clocked ones)
                     if (portClass == TMG_REGISTER_OUTPUT || portClass == TMG_STARTPOINT || portClass == TMG_IGNORE ||
                         portClass == TMG_GEN_CLOCK)
+                        continue;
+                    // Skip the same self-net arcs that were skipped when
+                    // counting fanin above (input bound to the same net as
+                    // the output), keeping both sides symmetrical.
+                    if (port.second.net == net)
                         continue;
                     DelayInfo comb_delay;
                     bool is_path = ctx->getCellDelay(usr.cell, usr.port, port.first, comb_delay);

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -2309,6 +2309,19 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
     }
 
     if (cell->type == id_SLICE_LUTX) {
+        // Fractured LUT pairs share their physical input pins: the
+        // post-placement and post-routing legalisation bind a shared pin to
+        // BOTH cells of the pair and erase the X_ORIG_PORT_<pin> attribute
+        // on the cell whose logical function does not use it (it can even
+        // end up bound to the cell's own output net). Such a pin has no arc
+        // through THIS lut; reporting one creates false combinational
+        // cycles that deadlock the timing walk post-route.
+        if (fromPort == id_A1 || fromPort == id_A2 || fromPort == id_A3 || fromPort == id_A4 ||
+            fromPort == id_A5 || fromPort == id_A6) {
+            auto orig = cell->attrs.find(id("X_ORIG_PORT_" + fromPort.str(this)));
+            if (orig == cell->attrs.end() || orig->second.str.empty())
+                return false;
+        }
         if (xc7 && inst_id != -1) {
             int z = locInfo(cell->bel).bel_data[cell->bel.index].z;
             IdString tiletype = getBelTileType(cell->bel);

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -324,9 +324,9 @@ PipId Arch::getPipByName(IdString name) const
 IdString Arch::getPipName(PipId pip) const
 {
     NPNR_ASSERT(pip != PipId());
-    auto loc_info  = locInfo(pip);
-    auto pip_data  = loc_info.pip_data[pip.index];
-    auto tile_inst = chip_info->tile_insts[pip.tile];
+    const auto &loc_info  = locInfo(pip);
+    const auto &pip_data  = loc_info.pip_data[pip.index];
+    const auto &tile_inst = chip_info->tile_insts[pip.tile];
     auto site      = pip_data.site;
     auto bel       = pip_data.bel;
 
@@ -2247,7 +2247,7 @@ std::vector<GraphicElement> Arch::getDecalGraphics(DecalId decal) const
         int wires_per_side = int(((swb_x1 - swb_x0) - 2 * wire_margin) / wire_space);
 
         for (auto w : getTileWireRange(wire)) {
-            auto wire_data = locInfo(w).wire_data[w.index];
+            const auto &wire_data = locInfo(w).wire_data[w.index];
             if (wire_data.site != -1)
                 continue;
             int wx = (w.tile % chip_info->width) - (wire_tile % chip_info->width),

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -2300,6 +2300,62 @@ DecalXY Arch::getGroupDecal(GroupId pip) const { return {}; };
 
 // -----------------------------------------------------------------------
 
+IdString Arch::dspStripBusIndex(IdString port) const
+{
+    const std::string &s = port.str(this);
+    size_t n = s.size();
+    while (n > 0 && s[n - 1] >= '0' && s[n - 1] <= '9')
+        --n;
+    return id(s.substr(0, n));
+}
+
+bool Arch::dsp48e1IsCombinational(const CellInfo *cell) const
+{
+    // Combinational only if every internal register is bypassed. Params are
+    // stored as binary strings; any '1' bit means the register is enabled.
+    static const char *regs[] = {"AREG", "BREG",  "CREG", "DREG",    "ADREG",
+                                 "MREG", "PREG",  "ACASCREG", "BCASCREG"};
+    for (const char *r : regs) {
+        auto it = cell->params.find(id(r));
+        // Property::as_bool() handles the numeric (bit-string) params without
+        // asserting is_string; any non-zero register value means it's enabled.
+        if (it != cell->params.end() && it->second.as_bool())
+            return false;
+    }
+    return true;
+}
+
+double Arch::dsp48e1CombInputDelayNS(IdString base) const
+{
+    // Conservative propagation delay from a DSP48E1 data input to any timed
+    // output: worst case over the prjxray DSP_R.sdf combinational variants
+    // (all internal registers bypassed). 0.0 == not a combinational data input.
+    const std::string &s = base.str(this);
+    if (s == "A") return 5.40;
+    if (s == "ACIN") return 5.20;
+    if (s == "INMODE") return 5.48;
+    if (s == "D") return 5.05;
+    if (s == "B") return 3.85;
+    if (s == "BCIN") return 3.61;
+    if (s == "OPMODE") return 2.52;
+    if (s == "ALUMODE") return 2.29;
+    if (s == "CARRYINSEL") return 2.11;
+    if (s == "C") return 2.02;
+    if (s == "MULTSIGNIN") return 1.71;
+    if (s == "PCIN") return 1.71;
+    if (s == "CARRYIN") return 1.61;
+    if (s == "CARRYCASCIN") return 1.34;
+    return 0.0;
+}
+
+bool Arch::dsp48e1IsTimedOutput(IdString base) const
+{
+    const std::string &s = base.str(this);
+    return s == "P" || s == "PCOUT" || s == "CARRYOUT" || s == "CARRYCASCOUT" ||
+           s == "MULTSIGNOUT" || s == "PATTERNDETECT" || s == "PATTERNBDETECT" ||
+           s == "OVERFLOW" || s == "UNDERFLOW" || s == "ACOUT" || s == "BCOUT";
+}
+
 bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const
 {
     int tt_id = -1, inst_id = -1;
@@ -2347,6 +2403,18 @@ bool Arch::getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort
                 delay.delay = 200; // FIXME
                 return true;
             }
+    } else if (cell->type == id("DSP48E1_DSP48E1")) {
+        // Combinational DSP48E1 (Phase 1). getPortTimingClass leaves any
+        // registered config as TMG_IGNORE, so this is only reached when the
+        // DSP is fully combinational. Conservative per-input delay; the
+        // accurate per-variant chipdb model is Phase 2. Upstream PR material.
+        if (!dsp48e1IsCombinational(cell))
+            return false;
+        double d = dsp48e1CombInputDelayNS(dspStripBusIndex(fromPort));
+        if (d <= 0.0 || !dsp48e1IsTimedOutput(dspStripBusIndex(toPort)))
+            return false;
+        delay = getDelayFromNS(d);
+        return true;
     }
     return false;
 }
@@ -2389,6 +2457,17 @@ TimingPortClass Arch::getPortTimingClass(const CellInfo *cell, IdString port, in
             return TMG_COMB_INPUT;
         if (port == id("O"))
             return TMG_COMB_OUTPUT;
+    } else if (cell->type == id("DSP48E1_DSP48E1")) {
+        // Phase 1: only the fully-combinational DSP48E1. Registered configs
+        // stay transparent (TMG_IGNORE) exactly as before -> no regression.
+        if (!dsp48e1IsCombinational(cell))
+            return TMG_IGNORE;
+        IdString base = dspStripBusIndex(port);
+        if (dsp48e1IsTimedOutput(base))
+            return TMG_COMB_OUTPUT;
+        if (dsp48e1CombInputDelayNS(base) > 0.0)
+            return TMG_COMB_INPUT;
+        return TMG_IGNORE; // CLK / CE* / RST* / config pins
     }
     return TMG_IGNORE;
 }

--- a/xilinx/arch.h
+++ b/xilinx/arch.h
@@ -1552,6 +1552,13 @@ struct Arch : BaseCtx
     bool getCellDelay(const CellInfo *cell, IdString fromPort, IdString toPort, DelayInfo &delay) const;
     // Get the port class, also setting clockInfoCount to the number of TimingClockingInfos associated with a port
     TimingPortClass getPortTimingClass(const CellInfo *cell, IdString port, int &clockInfoCount) const;
+
+    // DSP48E1 combinational timing helpers (see arch.cc). Phase 1: model the
+    // fully-combinational DSP48E1; registered configs stay TMG_IGNORE.
+    IdString dspStripBusIndex(IdString port) const;
+    bool dsp48e1IsCombinational(const CellInfo *cell) const;
+    double dsp48e1CombInputDelayNS(IdString base) const;
+    bool dsp48e1IsTimedOutput(IdString base) const;
     // Get the TimingClockingInfo of a port
     TimingClockingInfo getPortClockingInfo(const CellInfo *cell, IdString port, int index) const;
 

--- a/xilinx/arch_pybindings.cc
+++ b/xilinx/arch_pybindings.cc
@@ -43,7 +43,8 @@ void arch_wrap_python()
                            .def("checksum", &Context::checksum)
                            .def("pack", &Context::pack)
                            .def("place", &Context::place)
-                           .def("route", &Context::route);
+                           .def("route", &Context::route)
+                           .def("reportClockFmaxJson", &Context::reportClockFmaxJson);
 
     fn_wrapper_2a<Context, decltype(&Context::isValidBelForCell), &Context::isValidBelForCell, pass_through<bool>,
                   addr_and_unwrap<CellInfo>, conv_from_str<BelId>>::def_wrap(ctx_cls, "isValidBelForCell");

--- a/xilinx/python/bbaexport.py
+++ b/xilinx/python/bbaexport.py
@@ -229,18 +229,22 @@ def main():
 					wire_count += 1
 				node_wire_count.append(wire_count)
 				node_intent.append(constid.make("PSEUDO_VCC" if i == 1 else "PSEUDO_GND"))
-		# Create the global Vcc and Ground nodes
+		# Create the global Vcc and Ground nodes.
+		# PATCH: include the GLBL wire of EVERY tile (not only column x=0):
+		# the pseudo const driver bel can be placed in any tile, and if its
+		# GLBL wire is not part of the global node the constant can only
+		# reach its own row -> 'Invalid global constant node' at route time.
 		for i in range(2):
 			wire_count = 0
 			bba.label("n{}_tw".format(len(node_wire_count)))
 			for row in range(d.height):
-				t = d.tiles_by_xy[0, row]
-				tileidx = row * d.width
-				bba.u32(tileidx)
-				wire_idx = tile_types[tile_insts[tileidx].tile_type].global_vcc_wire_index if i == 1 else tile_types[tile_insts[tileidx].tile_type].global_gnd_wire_index
-				bba.u32(wire_idx)
-				tile_insts[tileidx].tilewire_to_node[wire_idx] = len(node_wire_count)
-				wire_count += 1
+				for col in range(d.width):
+					tileidx = row * d.width + col
+					bba.u32(tileidx)
+					wire_idx = tile_types[tile_insts[tileidx].tile_type].global_vcc_wire_index if i == 1 else tile_types[tile_insts[tileidx].tile_type].global_gnd_wire_index
+					bba.u32(wire_idx)
+					tile_insts[tileidx].tilewire_to_node[wire_idx] = len(node_wire_count)
+					wire_count += 1
 			node_wire_count.append(wire_count)
 			node_intent.append(constid.make("PSEUDO_VCC" if i == 1 else "PSEUDO_GND"))
 		print("Exporting tile and site instances...")

--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -185,6 +185,12 @@ void Arch::parseXdc(std::istream &in)
             }
             if (!got_period)
                 log_error("found create_clock without period (on line %d)", lineno);
+            if (cursor >= int(arguments.size())) {
+                // virtual clock (no target ports/nets): not supported; skip it
+                // instead of crashing with std::out_of_range
+                log_warning("ignoring virtual clock (unsupported, on line %d)\n", lineno);
+                continue;
+            }
             std::vector<NetInfo *> dest = get_nets(arguments.at(cursor));
             for (auto n : dest) {
                 n->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint);


### PR DESCRIPTION
 
  This is a batch of independent fixes we have been carrying (and shipping) along the integration work of this toolchain  in Apio and Icestudio with the best feedback  of our community , now contributed back (thanks for your work).

Each commit is self-contained and reviewable on its own - happy to split any of them into separate PRs if you prefer.

  ## Routing

  - **router2: make wire reservation conflict-aware**,  fixes the 0.9.0/0.9.1
    regression (#ISSUE, related to #97) where any design with a registered counter
    fails with `Failed to route arc ... BQ to B1`. Root cause: packed counter bits
    contend for shared corridor wires among themselves; the reservation fixpoint
    flip-flopped ownership forever, and the `iters < 5` cap from 6b46121f left the
    last winner owning every shared wire, starving the loser arcs. A contested wire
    now becomes nobody's (absorbing state, congestion arbitrates), LOCKED wires
    stay hard keepouts (`reserved_locked`), and the fixpoint provably terminates.
    Verified on xc7a35t: 24-bit and 32-bit counters, PLL + dual counter, and a
    wide-mux control design all route again.
  - **bbaexport: span the global VCC/GND nodes across every tile**, the global
    constant node only included column x=0, so a pseudo const driver placed
    elsewhere could not reach it ("Invalid global constant node" on VCC/GND-to-pad
    and PLL designs). Costs ~0.5 MB per chipdb `.bin`. Fixes #38, fixes #41.
  - **router2: use std::map for `PerWireData::bound_nets`**,  under mingw-w64 the
    `boost::container::flat_map` sorted invariant breaks (`count()` true but
    `at()` throws), crashing every route on Windows. Byte-equal fasm output on
    Linux verified before/after on our e2e design set.
  
  ## Timing analysis

  - **timing: skip cell self-loop arcs in the timing walk**,  an input pin bound to
    the cell's own output net (xc7 post-route LUT pin fixup) deadlocked the
    topological sort as a false combinational loop, aborting post-route timing.
  - **xc7: no timing arc through unused shared pins of fractured LUTs**,  LUT-pair
    legalisation binds shared physical pins to both cells; `getCellDelay` declared
    arcs through pins with no path through the LUT, creating false combinational
    cycles ("timing analysis failed"). Only report A1..A6 arcs when
    `X_ORIG_PORT_<pin>` is present.
  - **xc7: model combinational DSP48E1 timing (phase 1)**,  fully-combinational
    DSP48E1s (all `*REG` = 0) were invisible to timing analysis, over-reporting
    fmax on DSP paths. Conservative per-input worst-case delays from the prjxray
    `DSP_R.sdf` variants, validated against Vivado 2026.1 reference runs.
    Registered configs keep the previous `TMG_IGNORE` behaviour.
  - **timing: expose per-clock fmax to Python as `reportClockFmaxJson()`**,  this
    fork lacks mainline's `--report`; `--post-route` scripts (e.g. apio's timing
    report) need achieved/constraint frequencies. A `log_error` inside the walk is
    caught and reported as an empty table instead of killing a routed flow.

  ## Robustness / portability

  - **xdc: don't crash on `create_clock` without a target (virtual clock)** , 
    common in Vivado-generated XDCs; warn and skip instead of an uncaught
    `std::out_of_range`.
  - **xc7: don't copy chipdb PODs by value in `getPipName`/`getWireName`**,  the
    copies could read past the end of the memory-mapped chipdb: a hard page fault
    under the Windows file mapping and benign-but-UB out-of-bounds reads on
    Linux/macOS (caught with ASan/UBSan). Const references read only real fields.
  
  ## Validation 

  These changes ship in the apio `openxc7` package (2026-07-31 release): E2E
  (yosys -> nextpnr-xilinx -> fasm2frames -> xc7frames2bit) on xc7a35t/xc7a100t/
  xc7a200t across linux-x86-64, windows-amd64 (wine) and darwin-arm64, with
  byte-identical chipdb across platforms and hardware-tested bitstreams.

