### PR TITLE
router2: make wire reservation conflict-aware (fixes 0.9.x counter routing)

### DIFF
--- a/common/router2.cc
+++ b/common/router2.cc
@@ -76,6 +76,11 @@ struct Router2
         float total() const { return cost + togo_cost; }
     };
 
+    // reserved_net sentinel: the wire sits on the forced corridor of MORE
+    // THAN ONE arc. Absorbing state — once contested, no net ever re-claims
+    // it (this is what makes the reservation fixpoint terminate).
+    static constexpr int RESERVED_CONTESTED = -2;
+
     struct PerWireData
     {
         // nextpnr
@@ -86,8 +91,13 @@ struct Router2
         float hist_cong_cost = 1.0;
         // Wire is unavailable as locked to another arc
         bool unavailable = false;
-        // This wire has to be used for this net
+        // This wire has to be used for this net (-1 = unreserved;
+        // RESERVED_CONTESTED = two arcs' forced corridors share it, so no
+        // net pre-claims it and the congestion loop arbitrates instead)
         int reserved_net = -1;
+        // reserved_net came from a LOCKED binding (frozen macro / clock
+        // spine): a hard keepout for every other net, never contestable
+        bool reserved_locked = false;
         // The notional location of the wire, to guarantee thread safety
         int16_t x = 0, y = 0;
         // Visit data
@@ -224,6 +234,7 @@ struct Router2
                     // Vivado's PIP list omits) itself, deterministically, using
                     // a real maze route instead of an external BFS guess.
                     pwd.reserved_net = bound->udata;
+                    pwd.reserved_locked = true;
                 }
             }
 
@@ -432,7 +443,7 @@ struct Router2
         // and LUT
         if (iter_count > 0)
             return false; // heuristic to assume we've hit general routing
-        if (wire_data(wire).reserved_net != -1 && wire_data(wire).reserved_net != net->udata)
+        if (wire_data(wire).reserved_net >= 0 && wire_data(wire).reserved_net != net->udata)
             return true; // reserved for another net
         for (auto bp : ctx->getWireBelPins(wire))
             if ((net->driver.cell == nullptr || bp.bel == net->driver.cell->bel) &&
@@ -469,8 +480,29 @@ struct Router2
             auto &wd = wire_data(cursor);
             if (ctx->debug)
                 log("      %s\n", ctx->nameOfWire(cursor));
-            did_something |= (wd.reserved_net != net->udata);
-            wd.reserved_net = net->udata;
+            if (wd.reserved_locked) {
+                if (wd.reserved_net != net->udata)
+                    // the corridor crosses another net's LOCKED wire: hard
+                    // keepout, nothing to claim beyond it — stop and let the
+                    // arc route (or fail) on its own merits
+                    break;
+                // our own locked wire: already effectively reserved
+            } else if (wd.reserved_net == RESERVED_CONTESTED) {
+                // shared corridor trunk: stays contested (absorbing state)
+            } else if (wd.reserved_net != -1 && wd.reserved_net != net->udata) {
+                // two arcs' forced corridors share this wire. Handing it to
+                // either net starves the other, and flip-flopping ownership
+                // never converges (the historic fixpoint hang) — mark it
+                // contested so NO net pre-claims it and the congestion loop
+                // arbitrates instead.
+                if (ctx->debug)
+                    log("      contested with %s\n", ctx->nameOf(nets_by_udata.at(wd.reserved_net)));
+                wd.reserved_net = RESERVED_CONTESTED;
+                did_something = true;
+            } else {
+                did_something |= (wd.reserved_net != net->udata);
+                wd.reserved_net = net->udata;
+            }
             if (cursor == src)
                 break;
             WireId next_cursor;
@@ -508,7 +540,9 @@ struct Router2
                 for (size_t i = 0; i < net->users.size(); i++)
                     did_something |= reserve_wires_for_arc(net, i);
             }
-        } while (did_something && ++iters < 5);
+        } while (did_something && ++iters < 100);
+        if (did_something)
+            log_warning("router2: wire reservation did not converge after %d sweeps\n", iters);
     }
 
     void reset_wires(ThreadContext &t)
@@ -650,7 +684,7 @@ struct Router2
                     auto &wd = flat_wires[next];
                     if (wd.unavailable)
                         continue;
-                    if (!unbounded && wd.reserved_net != -1 && wd.reserved_net != net->udata)
+                    if (!unbounded && wd.reserved_net >= 0 && wd.reserved_net != net->udata)
                         continue; // final pass ignores reservations too (cf. router1 ripup)
                     if (!unbounded && (int(wd.bound_nets.size()) > (allowed_cong + 1) ||
                         (allowed_cong == 0 && wd.bound_nets.size() == 1 && !wd.bound_nets.count(net->udata))))
@@ -781,7 +815,7 @@ struct Router2
                 auto &wd = flat_wires[next];
                 if (wd.unavailable)
                     continue;
-                if (wd.reserved_net != -1 && wd.reserved_net != net->udata)
+                if (wd.reserved_net >= 0 && wd.reserved_net != net->udata)
                     continue;
                 if (wd.bound_nets.size() > 1 || (wd.bound_nets.size() == 1 && !wd.bound_nets.count(net->udata)))
                     continue; // never allow congestion in backwards routing
@@ -891,7 +925,7 @@ struct Router2
                 auto &nwd = flat_wires.at(next_idx);
                 if (nwd.unavailable)
                     continue;
-                if (nwd.reserved_net != -1 && nwd.reserved_net != net->udata)
+                if (nwd.reserved_net >= 0 && nwd.reserved_net != net->udata)
                     continue;
                 if (nwd.bound_nets.count(net->udata) && nwd.bound_nets.at(net->udata).second != dh)
                     continue;


### PR DESCRIPTION
Since 6b46121f, any design with a registered counter fails to route on
`stable-backports` (and on the 0.9.0 / 0.9.1 releases). The same-slice
FF->LUT feedback arc dies with:

```
ERROR: Failed to route arc ... from SITEWIRE/SLICE_*/BQ to SITEWIRE/SLICE_*/B1
```

A blinky with a counter is enough to reproduce it, on any part and any seed.
This is the class of failure reported in #97.

## Root cause

`reserve_wires_for_arc()` unconditionally overwrites `reserved_net` while
walking each sink's forced corridor. When two arcs' corridors share a wire,
which the packed counter bits of a carry chain do *between themselves*, since
adjacent bits' escape corridors overlap — every fixpoint sweep flips the
owner and `did_something` never clears.

That loop is as old as the reservation code, but 6b46121f started feeding it
contended state (LOCKED wires now carry `reserved_net`) and capped the
fixpoint at 5 sweeps rather than fixing it. After the cap, the last sweep's
winner owns every shared wire, and the losing arcs find their only escape
corridor reserved for someone else, a hard routing failure.

Removing the cap alone is not a fix: it restores the historic infinite loop
(verified).

## The fix: a contested wire is nobody's wire

- `reserved_net` gains an absorbing `RESERVED_CONTESTED` state. When a walk
  meets a wire already reserved for a different net, that wire becomes
  contested and is never re-claimed; the normal congestion loop arbitrates
  it. Every wire now moves monotonically through
  `unreserved → reserved → contested`, so the fixpoint provably terminates
  and the sweep cap becomes a pure safety net (raised to 100 with a
  `log_warning`; never hit in practice — it converges in 2–3 sweeps).
- Reservation gates change from `!= -1` to `>= 0`, so contested wires block
  nobody.
- LOCKED wires (frozen macros, clock spine) get `reserved_locked` and are
  never contestable: they stay a hard keepout for every other net, and a
  corridor walk that crosses one simply stops claiming there.

## Validation

On xc7a35t, with the chipdb exported from this tree, the previously failing
designs route again:

- 2-module 24-bit counter (hierarchical, unflattened)
- PLLE2 + dual counter
- 32-bit counter, the class reported in #97

and a wide-mux control design is unchanged.

The commit that introduced the regression was identified by bisect (7 steps,
building and routing each candidate).