### PR TITLE
xc7: place SRL cascades like carry chains; route longer chains via Q

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -622,6 +622,29 @@ struct FasmBackend
                     continue;
 
                 if (belname.substr(1) == "DI1MUX") {
+                    // prjxray names the non-default leg of these muxes after
+                    // BOTH signals sharing it -- the LUTRAM write-data
+                    // broadcast and the SRL MC31 cascade run through one
+                    // config bit: ADI1MUX -> BDI1_BMC31, BDI1MUX -> DI_CMC31,
+                    // CDI1MUX -> DI_DMC31 (there is no DDI1MUX).  The
+                    // default own-letter leg (AI/BI/CI) keeps its plain name.
+                    // Emitting the bare site-wire name (e.g. BMC31) makes
+                    // fasm2frames reject the feature.
+                    if (pinname != std::string(1, belname[0]) + "I") {
+                        switch (belname[0]) {
+                        case 'A':
+                            pinname = "BDI1_BMC31";
+                            break;
+                        case 'B':
+                            pinname = "DI_CMC31";
+                            break;
+                        case 'C':
+                            pinname = "DI_DMC31";
+                            break;
+                        default:
+                            break;
+                        }
+                    }
                     belname = "DI1MUX";
                 }
 

--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -697,6 +697,171 @@ void XilinxPacker::pack_srls()
             }
         }
     }
+    constrain_srl_cascades();
+}
+
+// SRLC32E cascades (shift registers deeper than 32, chained through Q31).
+// The MC31 wire Q31 maps to only exists INSIDE a SLICEM: the cascade muxes
+// run top-down D->C->B->A (xDI1MUX <- (x+1)MC31) and no route from MC31 to
+// the general fabric exists.  Two consequences the packer must handle, or
+// the placer scatters the chain and the MC31 arc is physically unroutable:
+//
+//  - a cascade group of up to four SRLs must occupy D,C,B,A of ONE slice,
+//    exactly like a carry chain (constr cluster, head at D);
+//  - any Q31 link that cannot stay inside a slice (fifth and later chain
+//    elements, or a Q31 consumer that is not another SRL's D) must instead
+//    leave through the ordinary Q output with the read address tied to 31
+//    -- the same value, fabric-routable.  Only possible when Q is unused,
+//    but a used Q means the design also taps that segment live.
+void XilinxPacker::constrain_srl_cascades()
+{
+    auto is_srl32 = [&](const CellInfo *ci) {
+        return ci->type == id_SLICE_LUTX && str_or_default(ci->attrs, ctx->id("X_ORIG_TYPE")) == "SRLC32E";
+    };
+    NetInfo *vcc = ctx->nets.at(ctx->id("$PACKER_VCC_NET")).get();
+    auto reads_bit31 = [&](const CellInfo *ci) {
+        for (auto a : {id_A2, id_A3, id_A4, id_A5, id_A6})
+            if (get_net_or_empty(ci, a) != vcc)
+                return false;
+        return true;
+    };
+
+    std::vector<CellInfo *> srls;
+    std::unordered_map<CellInfo *, CellInfo *> next_srl, prev_srl;
+    for (auto cell : sorted(ctx->cells)) {
+        CellInfo *ci = cell.second;
+        if (!is_srl32(ci))
+            continue;
+        srls.push_back(ci);
+        NetInfo *q31 = get_net_or_empty(ci, id_MC31);
+        if (q31 != nullptr && q31->users.size() == 1 && q31->users.at(0).port == id_DI1 &&
+            is_srl32(q31->users.at(0).cell)) {
+            next_srl[ci] = q31->users.at(0).cell;
+            prev_srl[q31->users.at(0).cell] = ci;
+        }
+    }
+    if (srls.empty())
+        return;
+
+    // Q31 links that must leave their slice, to be moved onto Q afterwards
+    std::vector<CellInfo *> offslice;
+    std::unordered_set<CellInfo *> visited;
+    int clusters = 0;
+    for (auto head : srls) {
+        if (prev_srl.count(head))
+            continue;
+        std::vector<CellInfo *> chain;
+        for (CellInfo *cur = head; cur != nullptr;) {
+            chain.push_back(cur);
+            visited.insert(cur);
+            auto fnd = next_srl.find(cur);
+            cur = (fnd == next_srl.end()) ? nullptr : fnd->second;
+        }
+        for (size_t g = 0; g < chain.size(); g += 4) {
+            size_t glen = std::min<size_t>(4, chain.size() - g);
+            if (glen > 1) {
+                // Imported (BEL-pinned) chains were already placed legally;
+                // adding constraints on top would fight the pin (cf. the
+                // pinned-root lesson in pack_carries).
+                bool pinned = false;
+                for (size_t i = 0; i < glen; i++)
+                    pinned |= bool(chain[g + i]->attrs.count(ctx->id("BEL")));
+                if (!pinned) {
+                    CellInfo *base = chain[g];
+                    base->constr_abs_z = true;
+                    base->constr_z = (3 << 4) | BEL_6LUT; // head at D6LUT
+                    for (size_t i = 1; i < glen; i++) {
+                        CellInfo *m = chain[g + i];
+                        m->constr_abs_z = true;
+                        m->constr_z = ((3 - int(i)) << 4) | BEL_6LUT; // then C, B, A
+                        m->constr_parent = base;
+                        m->constr_x = 0;
+                        m->constr_y = 0;
+                        base->constr_children.push_back(m);
+                    }
+                    clusters++;
+                }
+            }
+            CellInfo *tail = chain[g + glen - 1];
+            if (next_srl.count(tail))
+                offslice.push_back(tail);
+        }
+    }
+    // A chain with no head is a pure Q31 cycle: some link has to go through
+    // the fabric, and any of them may -- break the cycle at an arbitrary
+    // element and cluster the rest as one open chain.
+    for (auto ci : srls) {
+        if (visited.count(ci) || !next_srl.count(ci))
+            continue;
+        log_warning("SRL cell '%s' is part of a pure Q31 cascade cycle; breaking the cycle at its Q31 link\n",
+                    ci->name.c_str(ctx));
+        prev_srl.erase(next_srl.at(ci));
+        next_srl.erase(ci);
+        // (re-run is simplest: tail recursion depth is at most one because a
+        // broken cycle is an ordinary chain)
+        return constrain_srl_cascades();
+    }
+
+    // Cells whose Q31 net is not one of the in-slice cascade links kept
+    // above: multi-fanout Q31, a non-SRL consumer, or a group boundary.
+    for (auto ci : srls) {
+        NetInfo *q31 = get_net_or_empty(ci, id_MC31);
+        if (q31 == nullptr || next_srl.count(ci))
+            continue;
+        if (std::find(offslice.begin(), offslice.end(), ci) == offslice.end())
+            offslice.push_back(ci);
+    }
+
+    int rewired = 0;
+    for (auto ci : offslice) {
+        NetInfo *q31 = get_net_or_empty(ci, id_MC31);
+        if (q31 == nullptr)
+            continue;
+        if (q31->users.empty()) {
+            disconnect_port(ctx, ci, id_MC31);
+            continue;
+        }
+        NetInfo *q = get_net_or_empty(ci, id_O6);
+        if (q != nullptr && !q->users.empty()) {
+            if (reads_bit31(ci)) {
+                // Q already reads bit 31, so it carries the very value Q31
+                // does: fold the off-slice Q31 consumers into the Q net.
+                std::vector<PortRef> users(q31->users.begin(), q31->users.end());
+                for (auto &user : users) {
+                    disconnect_port(ctx, user.cell, user.port);
+                    connect_port(ctx, q, user.cell, user.port);
+                }
+                disconnect_port(ctx, ci, id_MC31);
+                rewired++;
+                continue;
+            }
+            log_error("SRL '%s': its Q31 cascade must go through the fabric (chain deeper than 128 bits, or a "
+                      "non-SRL consumer), which needs the Q output with the read address tied to 31 -- but Q is "
+                      "already in use with another address. Restructure the shift register (srl_style/shreg "
+                      "attributes) so this segment is not tapped.\n",
+                      ci->name.c_str(ctx));
+        }
+        disconnect_port(ctx, ci, id_MC31);
+        if (q != nullptr)
+            disconnect_port(ctx, ci, id_O6);
+        if (!ci->ports.count(id_O6)) {
+            ci->ports[id_O6].name = id_O6;
+            ci->ports[id_O6].type = PORT_OUT;
+        }
+        connect_port(ctx, q31, ci, id_O6);
+        for (auto a : {id_A2, id_A3, id_A4, id_A5, id_A6}) {
+            disconnect_port(ctx, ci, a);
+            if (!ci->ports.count(a)) {
+                ci->ports[a].name = a;
+                ci->ports[a].type = PORT_IN;
+            }
+            connect_port(ctx, vcc, ci, a);
+        }
+        rewired++;
+    }
+    if (clusters || rewired)
+        log_info("Constrained %d SRL cascade group(s) into single slices, moved %d Q31 link(s) to Q[31]\n", clusters,
+                 rewired);
 }
 
 void XilinxPacker::pack_constants()

--- a/xilinx/pack.h
+++ b/xilinx/pack.h
@@ -132,6 +132,7 @@ struct XilinxPacker
                           const std::vector<NetInfo *> &select, NetInfo *out, int zoffset);
 
     void pack_srls();
+    void constrain_srl_cascades();
 
     void split_carry4s();
 


### PR DESCRIPTION
# PR — openXC7/nextpnr-xilinx (branch cavearr:fix/srl-cascade -> stable-backports)

Title: **xc7: place SRL cascades like carry chains; route longer chains via Q**

---

Inferred shift registers deeper than 32 bits have never worked on xc7,
and the failure mode moved around as the toolchain evolved, which hid
that it was one missing feature all along:

- before the Q31→MC31 port mapping: pack dies with
  `No wire found for port Q31`;
- on current `stable-backports`: packing succeeds, and router2 correctly
  fails with an unroutable arc, e.g.
  `Failed to route arc ... SLICE_X2Y141/C6LUT_MC31 -> SLICE_X2Y143/ADI1MUX_OUT`.

## Root cause (three layers)

1. **The MC31 cascade only exists inside a SLICEM.** The muxes run
   top-down D->C->B->A (`xDI1MUX <- (x+1)MC31`, per the prjxray site pips:
   `ADI1MUX:BMC31`, `BDI1MUX:CMC31`, `CDI1MUX:DMC31`) and there is no
   route from MC31 to the general fabric. Nothing constrained Q31-chained
   SRLs into one slice, so HeAP placed them rows apart, the arc was
   physically impossible, exactly like a carry chain would be without its
   chain constraints.

2. **Chains beyond 128 bits cannot use MC31 at the slice boundary at
   all.** The link has to move onto the ordinary Q output with the read
   address tied to 31,  the same bit, fabric-routable (what Vivado does).

3. **The fasm feature names.** prjxray names the non-default leg of the
   DI1 muxes after BOTH signals that share it , the LUTRAM write-data
   broadcast and the SRL cascade ride one config bit: `BDI1_BMC31`,
   `DI_CMC31`, `DI_DMC31`. The emitter wrote the bare site-wire name
   (`BMC31`, …), which fasm2frames rejects.

## The fix

`pack_srls()` now walks Q31 chains and, per run of up to four SRLs,
builds a constr cluster (head at D6LUT, then C, B, A), the same
mechanism carry chains and distributed RAM already use. Q31 links that
cannot stay inside a slice (fifth and later elements, non-SRL consumers,
multi-fanout) are rewired to Q with A[6:2] tied high; if Q is busy with
another address that is a hard, actionable error instead of an
unroutable arc, and if Q already reads bit 31 the consumers fold into
the existing net. BEL-pinned (imported) chains are left as imported;
pure Q31 cycles are broken at an arbitrary link with a warning.
`write_routing_bel()` translates the DI1MUX feature names.

## Reproducer

```verilog
module srl_cascade #(parameter DEPTH = 128)
                    (input wire clk, output wire led);
    reg [DEPTH-1:0] sr = {{(DEPTH-1){1'b0}}, 1'b1};
    always @(posedge clk) sr <= {sr[DEPTH-2:0], sr[DEPTH-1]};
    assign led = sr[DEPTH-1];
endmodule
```

`yosys synth_xilinx` -> 4 chained SRLC32Es (8 at DEPTH=256, where the
group boundary exercises the Q rewrite).

## Verification

On xc7a35tcpg236-1: DEPTH=128 places all four SRLs in one SLICEM with
the three cascade features (`ALUT.DI1MUX.BDI1_BMC31`,
`BLUT.DI1MUX.DI_CMC31`, `CLUT.DI1MUX.DI_DMC31`); DEPTH=256 gives two
full slices with one Q31 link moved to Q[31]. Both route with router2,
`fasm2frames` accepts every feature, and `xc7frames2bit` produces
structurally valid bitstreams. Both designs are now positive tests in
our regression suite (linux / darwin / windows-under-wine), which is how
the gap was found in the first place.