### PR TITLE
xilinx: raise clock-buffer preplace BFS cap so SRCC clock pins can route

### DIFF
--- a/xilinx/pack_clocking_xcup.cc
+++ b/xilinx/pack_clocking_xcup.cc
@@ -36,7 +36,15 @@ BelId XilinxPacker::find_bel_with_short_route(WireId source, IdString beltype, I
 {
     if (source == WireId())
         return BelId();
-    const size_t max_visit = 50000; // effort/runtime tradeoff
+    // Effort cap on the pip-BFS. This must be large enough to reach the dedicated
+    // clock buffer from a *single-ended* clock-capable input pin: on xc7a200t an
+    // SRCC pin's dedicated route to a BUFGCTRL is ~75k wires away (vs ~6k for an
+    // MRCC/differential pin), so the historical 50000 cap silently failed to
+    // preplace BUFGs driven from SRCC pins — leaving the BUFG unplaceable and
+    // aborting P&R. The BFS runs once per clock-buffer driver over a hash-set, so
+    // a higher bound is cheap; it stays bounded by the (finite) routing graph.
+    size_t max_visit = 1000000;
+    bool dbg_route = getenv("NEXTPNR_DBG_SHORTROUTE") != nullptr;
     std::unordered_set<WireId> visited;
     // Layer-by-layer BFS instead of a single FIFO.  When the original
     // FIFO encountered two reachable target BELs at the same pip-distance
@@ -78,6 +86,9 @@ BelId XilinxPacker::find_bel_with_short_route(WireId source, IdString beltype, I
                           if (la.x != lb.x) return la.x < lb.x;
                           return la.z < lb.z;
                       });
+            if (dbg_route)
+                log_info("  [short-route] FOUND %s %s after visiting %d wires\n", beltype.c_str(ctx),
+                         ctx->nameOfBel(matches.front()), int(visited.size()));
             return matches.front();
         }
         std::vector<WireId> next_frontier;
@@ -92,6 +103,9 @@ BelId XilinxPacker::find_bel_with_short_route(WireId source, IdString beltype, I
         }
         frontier.swap(next_frontier);
     }
+    if (dbg_route)
+        log_info("  [short-route] NO %s reachable from source after visiting %d wires (frontier %s)\n",
+                 beltype.c_str(ctx), int(visited.size()), frontier.empty() ? "EXHAUSTED" : "hit-limit");
     return BelId();
 }
 


### PR DESCRIPTION
## Problem

A design that clocks logic from a **single-ended SRCC** clock-capable input pin
(for example an RGMII receive clock) fails P&R with:

```
ERROR: Unable to find legal placement for cell 'bg', check constraints and utilisation.
```

even though clock buffers are free. The identical design clocked from an
**MRCC / differential** pin builds fine. This has made SRCC-driven clocks
(a very common RGMII/Ethernet requirement) effectively unbuildable on the
open flow.

## Root cause

`find_bel_with_short_route()` (`xilinx/pack_clocking_xcup.cc`, used by both the
xc7 and xcup packers) BFS-es downhill pips from the clock net's driver to the
nearest dedicated clock buffer and preplaces the buffer there. Its effort cap
was hardcoded at **50000** wires.

Measured on xc7a200t (fbg484):

| driver pin | dedicated route to BUFGCTRL |
|---|---|
| MRCC / differential (R4/T4) | ~**6 069** wires |
| SRCC single-ended (B17, `IO_L11P_T1_SRCC_16`) | ~**75 492** wires |

The SRCC pin's dedicated path runs through the longer clock backbone
(`CLK_BUFG_REBUF` spine), so the BFS hit the 50000 cap **before** reaching the
buffer, returned no bel, the BUFG was never preplaced, and the placer then had
no legal spot for it → abort. So this was never a chip-db/routing-graph gap —
the path exists, the search just gave up too early.

## Fix

Raise the cap to **1,000,000**. The BFS runs once per clock-buffer driver over a
visited hash-set and is bounded by the finite routing graph, so the higher cap
is cheap. An optional `NEXTPNR_DBG_SHORTROUTE` env var traces the BFS outcome
(target bel + wires visited, or exhausted) to aid future clock-routing debug.

## Verification

With the patch, a `BUFG` driven from SRCC pin B17 preplaces to
`BUFGCTRL_X0Y16` (found at 75 492 wires), P&R completes, and the emitted FASM
carries a **real dedicated clock route** — `CLK_BUFG_REBUF` spine →
`CLK_BUFG_TOP_R` BUFGCTRL0 → `CLK_HROW_TOP_R` → `GCLK` into the fabric — not a
fabric detour. The same design aborted at placement before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)