### PR TITLE
xilinx: don't emit a conflicting width bit for the unused port of an SDP BRAM

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2063,6 +2063,25 @@ struct FasmBackend
                 write_bit(name.substr(0, name.size() - 1) + "B_18");
             }
         } else {
+            // A 36-bit (SDP) port already emits the _18 bits for BOTH the A and B
+            // halves of its direction — that is how prjxray encodes SDP width.  The
+            // paired port of the same direction is unused in SDP mode and defaults to
+            // width 1 here, which would then emit a conflicting _1 bit for a half that
+            // the SDP branch just set to _18 (prjxray rejects the FASM with
+            // "wanted to clear bit ... but was set by").  Skip it: in SDP mode the
+            // direction's width is fully described by the 36-bit port.
+            bool dir_is_sdp36 = false;
+            {
+                std::string dir = name.substr(0, name.size() - 2); // READ_WIDTH / WRITE_WIDTH
+                for (const char *ab : {"A", "B"}) {
+                    int w = int_or_default(ci->params, ctx->id(dir + "_" + ab), 0);
+                    int aw = (is_36 && w != 1 && w != 0) ? w / 2 : w;
+                    if (aw == 36)
+                        dir_is_sdp36 = true;
+                }
+            }
+            if (dir_is_sdp36 && actual_width == 1)
+                return;
             write_bit(name + "_" + std::to_string(actual_width));
         }
     }


### PR DESCRIPTION
## Problem

Any design containing an inferred **simple-dual-port block RAM** (e.g. a 512×32
dual-clock buffer — a very common shape) cannot be turned into a bitstream:
`fasm2frames` rejects the emitted FASM.

```
FasmInconsistentBits: FASM line "BRAM_L_X6Y225.RAMB18_Y1.READ_WIDTH_B_1"
wanted to clear bit (131867, 59, 19) but was set by FASM line
"BRAM_L_X6Y225.RAMB18_Y1.READ_WIDTH_B_18"
```

The only workaround was to synthesise with `-nobram`, pushing the memory into
distributed LUT RAM.

## Root cause

`write_bram_width()` is called once per (direction, port): `READ_WIDTH_A`,
`READ_WIDTH_B`, `WRITE_WIDTH_A`, `WRITE_WIDTH_B`.

In SDP mode one port of a direction has width 36. That call takes the 36-branch
and writes the `_18` bits for **both** halves of its direction — that is how
prjxray encodes an SDP width. The **paired** port of the same direction is
unused in SDP mode, defaults to width 1, falls into the `else` branch, and
writes `_1` for a half the SDP branch just set to `_18`. The two bits are
mutually exclusive, so prjxray refuses the FASM.

Emitted before the fix (one RAMB18):

```
READ_WIDTH_A_18   READ_WIDTH_B_1    READ_WIDTH_B_18
WRITE_WIDTH_A_1   WRITE_WIDTH_A_18  WRITE_WIDTH_B_18
```

## Fix

When a direction is in SDP-36 mode, skip the width-1 emission for that
direction's unused port — the direction's width is already fully described by
the 36-bit port's bits.

## Verification

On an RGMII/Ethernet design for xc7a200t (fbg484) with an inferred 512×32 SDP
BRAM:

- **before** — `fasm2frames` aborts with the error above; bitstream impossible
  without `-nobram`
- **after** — the BRAM emits only the consistent set (`SDP_READ_WIDTH_36`,
  `SDP_WRITE_WIDTH_36`, `READ_WIDTH_A/B_18`, `WRITE_WIDTH_A/B_18`),
  `fasm2frames` produces 20230 frames and `xc7frames2bit` produces a valid
  bitstream (correct `0xAA995566` sync word and IDCODE command sequence).
  No `-nobram` needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)