### PR TITLE
xilinx: preplace the single-site configuration primitives (STARTUPE2, ICAPE2, ...)

### DIFF
--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -1189,6 +1189,17 @@ void XC7Packer::pack_cfg()
             auto bel = "BSCAN_X0Y" + std::to_string(chain - 1) + "/BSCAN";
             ci->attrs[id_BEL] = bel;
             log_info("    Constraining '%s' to site '%s'\n", ci->name.c_str(ctx), bel.c_str());
+        } else if (ci->type == id_STARTUP_STARTUP || ci->type == id_DCIRESET_DCIRESET ||
+                   ci->type == id_DNA_PORT_DNA_PORT || ci->type == id_EFUSE_USR_EFUSE_USR ||
+                   ci->type == id_ICAP_ICAP || ci->type == id_FRAME_ECC_FRAME_ECC ||
+                   ci->type == id_USR_ACCESS_USR_ACCESS) {
+            // These configuration primitives live in a single dedicated site each. The
+            // placer has no way to discover that site on its own, so without an explicit
+            // preplacement it aborts with "Unable to find legal placement for cell". BSCAN
+            // above is the exception only because JTAG_CHAIN already names its site.
+            // Affects any design that instantiates e.g. STARTUPE2 to source a clock from
+            // CFGMCLK, or ICAPE2 / DNA_PORT for configuration access.
+            preplace_unique(ci);
         }
     }
 }


### PR DESCRIPTION
## Problem

Instantiating `STARTUPE2` — the standard way to clock a design from `CFGMCLK`
when you don't want to use an external oscillator — aborts place-and-route:

```
ERROR: Unable to find legal placement for cell 'u_startup', check constraints and utilisation.
```

The same applies to `ICAPE2`, `DNA_PORT`, `DCIRESET`, `EFUSE_USR`, `FRAME_ECCE2`
and `USR_ACCESSE2`.

## Root cause

`pack_cfg()` (`xilinx/pack_io_xc7.cc`) transforms eight configuration
primitives, but only `BSCAN` is given a BEL — and only because `JTAG_CHAIN`
names its site. The other seven each live in a **single dedicated site**, which
the placer has no way to discover on its own, so the cell stays unplaced and
placement fails.

## Fix

Preplace them with `preplace_unique()` — the helper already used for `PS7` and
`PCIE_2_1`.

## Minimal reproduction (xc7a200t, fbg484)

A counter clocked from `CFGMCLK`, nothing else:

```verilog
module top(output led);
  wire mclk, eos;
  STARTUPE2 #(.PROG_USR("FALSE"), .SIM_CCLK_FREQ(0.0)) u_startup (
      .CFGCLK(), .CFGMCLK(mclk), .EOS(eos),
      .CLK(1'b0),.GSR(1'b0),.GTS(1'b0),.KEYCLEARB(1'b0),.PACK(1'b0),
      .USRCCLKO(1'b0),.USRCCLKTS(1'b0),.USRDONEO(1'b0),.USRDONETS(1'b0));
  reg [24:0] c = 0;
  always @(posedge mclk) c <= c + 1'b1;
  assign led = c[24];
endmodule
```

```tcl
set_property -dict {PACKAGE_PIN B13 IOSTANDARD LVCMOS18} [get_ports led]
```

| | outcome |
|---|---|
| base (`f8e7643`) | `ERROR: Unable to find legal placement for cell 'u_startup'` |
| with this patch | place-and-route completes, FASM written (28658 bytes) |

`STARTUP` already has FASM emission support (`fasm.cc`), so the only thing
missing was the placement.

This is independent of my other open PRs (#109–#112) — different file, builds
standalone off `stable-backports`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)