### PR TITLE
common: add mainline-style --report (timing + utilization JSON)

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -121,6 +121,8 @@ po::options_description CommandHandler::getGeneralOptions()
     general.add_options()("post-route", po::value<std::vector<std::string>>(), "python file to run after routing");
 
 #endif
+    general.add_options()("report", po::value<std::string>(),
+                          "write timing and utilization report in JSON format");
     general.add_options()("json", po::value<std::string>(), "JSON design file to ingest");
     general.add_options()("write", po::value<std::string>(), "JSON design file to write");
     general.add_options()("seed", po::value<int>(), "seed value for random number generator");
@@ -353,6 +355,15 @@ int CommandHandler::executeMain(std::unique_ptr<Context> ctx)
         }
 
         customBitstream(ctx.get());
+    }
+
+    if (vm.count("report")) {
+        std::string filename = vm["report"].as<std::string>();
+        std::ofstream f(filename);
+        if (!f)
+            log_error("Failed to open report file %s for writing.\n", filename.c_str());
+        f << ctx->reportJson();
+        log_info("Report written to %s.\n", filename.c_str());
     }
 
     if (vm.count("write")) {

--- a/common/nextpnr.h
+++ b/common/nextpnr.h
@@ -879,8 +879,12 @@ struct Context : Arch, DeterministicRNG
 
     // provided by timing.cc; computes timing on the current (routed) design
     // and returns per-clock fmax/target as a JSON string. Exposed to Python
-    // for --post-route report scripts (the fork lacks mainline's --report).
+    // for --post-route report scripts.
     std::string reportClockFmaxJson();
+
+    // provided by timing.cc; the full --report document (mainline nextpnr's
+    // schema: critical_paths / fmax / utilization).
+    std::string reportJson();
 
     // --------------------------------------------------------------
 

--- a/common/timing.cc
+++ b/common/timing.cc
@@ -732,9 +732,14 @@ void assign_budget(Context *ctx, bool quiet)
         log_info("Checksum: 0x%08x\n", ctx->checksum());
 }
 
-std::string Context::reportClockFmaxJson()
+namespace {
+// Per-clock achieved fmax + constraint, keyed by the raw clock net name.
+// Empty on a failed timing walk (combinatorial loops, incomplete timing
+// ports, ...): a failed report must not kill an already successfully
+// routed flow.
+std::map<std::string, std::pair<double, double>> compute_clock_fmax(Context *ctx)
 {
-    Context *ctx = this;
+    std::map<std::string, std::pair<double, double>> out;
     std::map<IdString, double> clock_fmax;
     try {
         CriticalPathMap crit_paths;
@@ -755,31 +760,82 @@ std::string Context::reportClockFmaxJson()
                 clock_fmax[a.clock] = Fmax;
         }
     } catch (log_execution_error_exception &) {
-        // the timing walk can log_error (combinatorial loops, incomplete
-        // timing ports, ...); a failed REPORT must not kill an already
-        // successfully routed flow -> report no clocks instead
-        return "{}";
+        return out;
     }
 
-    std::string json = "{";
-    bool first = true;
     for (auto &clock : clock_fmax) {
         float target = ctx->setting<float>("target_freq") / 1e6;
         auto ni = ctx->nets.find(clock.first);
         if (ni != ctx->nets.end() && ni->second->clkconstr)
             target = 1000 / ctx->getDelayNS(ni->second->clkconstr->period.minDelay());
-        json += first ? "\"" : ", \"";
-        for (char c : clock.first.str(ctx)) {
-            if (c == '"' || c == '\\')
-                json += '\\';
-            json += c;
-        }
+        out[clock.first.str(ctx)] = {clock.second, target};
+    }
+    return out;
+}
+
+std::string json_escape(const std::string &s)
+{
+    std::string r;
+    for (char c : s) {
+        if (c == '"' || c == '\\')
+            r += '\\';
+        r += c;
+    }
+    return r;
+}
+} // namespace
+
+std::string Context::reportClockFmaxJson()
+{
+    std::string json = "{";
+    bool first = true;
+    for (auto &clock : compute_clock_fmax(this)) {
         char buf[80];
-        snprintf(buf, sizeof(buf), "\": {\"achieved\": %.2f, \"constraint\": %.2f}", clock.second, target);
-        json += buf;
+        snprintf(buf, sizeof(buf), "\": {\"achieved\": %.2f, \"constraint\": %.2f}", clock.second.first,
+                 clock.second.second);
+        json += (first ? "\"" : ", \"") + json_escape(clock.first) + buf;
         first = false;
     }
     json += "}";
+    return json;
+}
+
+std::string Context::reportJson()
+{
+    // The document mirrors mainline nextpnr's --report schema
+    // (critical_paths / fmax / utilization), with the clock-name aliasing
+    // apio's report formatter expects: '$iopadmap$<port>' (the net yosys
+    // inserts for a clock input port) shows the port name itself, other
+    // yosys internals show as "(internal) <last-segment>".
+    std::string json = "{\n    \"critical_paths\": [],\n    \"fmax\": {";
+    bool first = true;
+    for (auto &clock : compute_clock_fmax(this)) {
+        std::string name = clock.first;
+        if (name.rfind("$iopadmap$", 0) == 0)
+            name = name.substr(10);
+        else if (!name.empty() && name[0] == '$')
+            name = "(internal) " + name.substr(name.find_last_of('$') + 1);
+        char buf[80];
+        snprintf(buf, sizeof(buf), "\": {\"achieved\": %.2f, \"constraint\": %.2f}", clock.second.first,
+                 clock.second.second);
+        json += (first ? "\"" : ", \"") + json_escape(name) + buf;
+        first = false;
+    }
+    json += "},\n    \"utilization\": {";
+    std::map<std::string, int> avail, used;
+    for (auto bel : getBels())
+        avail[getBelType(bel).str(this)]++;
+    for (auto &cell : cells)
+        used[cell.second->type.str(this)]++;
+    first = true;
+    for (auto &kv : avail) {
+        char buf[64];
+        snprintf(buf, sizeof(buf), "\": {\"available\": %d, \"used\": %d}", kv.second,
+                 used.count(kv.first) ? used.at(kv.first) : 0);
+        json += (first ? "\"" : ", \"") + json_escape(kv.first) + buf;
+        first = false;
+    }
+    json += "}\n}\n";
     return json;
 }
 


### PR DESCRIPTION
The fork predates mainline nextpnr's `--report`. The openXC7/apio flow worked around it with `--post-route` running a python report script, which forces apio to inject a dynamic `ENV_BUILD_PATH` env var so the script knows where to write, invisible to `apio raw -v` and making the printed nextpnr command irreproducible (FPGAwars/apio#918).

This implements `--report <file>` natively:

  - the per-clock fmax computation is factored out of
    `reportClockFmaxJson()` (its string output is unchanged) and reused
    by the new `Context::reportJson()`
  - the emitted document follows mainline's schema
    (`critical_paths` / `fmax` / `utilization`), verified against a real
    nextpnr-ice40 `--report` output
  - clock names get the aliasing apio's report formatter expects
    (`$iopadmap$<port>` → the port name, other yosys internals →
    `(internal) <tail>`)
  - the flag lives outside the `NO_PYTHON` guard: unlike the hook, it
    needs no python
  - `--post-route` stays, it is a generic scripting hook with other uses

Validation: the same design run through both paths (the python hook vs `--report`) produces identical fmax tables and identical utilization for every row with `used > 0`; remaining diffs are unused config pseudo-bels where the python bindings collapse ILOGICE2/E3 variants that the native code keeps separate.

