### PR TITLE
xdc: warn when a target selector matches nothing (fixes #99)

### DIFF
--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -102,6 +102,9 @@ void Arch::parseXdc(std::istream &in)
         IdString cellname = id(strip_quotes(split_name));
         if (cells.count(cellname))
             tgt_cells.push_back(cells.at(cellname).get());
+        else
+            log_warning("%s: no cell named '%s' (on line %d) - this target is ignored\n",
+                        split.front().c_str(), cellname.c_str(this), lineno);
         return tgt_cells;
     };
 
@@ -122,6 +125,9 @@ void Arch::parseXdc(std::istream &in)
         NetInfo *maybe_net = getNetByAlias(netname);
         if (maybe_net != nullptr)
             tgt_nets.push_back(maybe_net);
+        else
+            log_warning("%s: no net or port named '%s' (on line %d) - this target is ignored\n",
+                        split.front().c_str(), netname.c_str(this), lineno);
         return tgt_nets;
     };
 
@@ -192,6 +198,11 @@ void Arch::parseXdc(std::istream &in)
                 continue;
             }
             std::vector<NetInfo *> dest = get_nets(arguments.at(cursor));
+            if (dest.empty())
+                log_warning("create_clock: target %s matched nothing, so the %.3f ns constraint "
+                            "was NOT applied (on line %d). The clock domain keeps the default "
+                            "target and will be reported as meeting timing at that default.\n",
+                            arguments.at(cursor).c_str(), period, lineno);
             for (auto n : dest) {
                 n->clkconstr = std::unique_ptr<ClockConstraint>(new ClockConstraint);
                 n->clkconstr->period = getDelayFromNS(period);


### PR DESCRIPTION
Fixes #99.

## The defect

`get_nets` and `get_cells` in `xilinx/xdc.cc` resolve a selector with an exact lookup and, on a miss, **return an empty vector and say nothing**. Every command built on them then iterates over the empty vector and does nothing at all.

`create_clock` is where it hurts. A typo'd or renamed net leaves the clock domain unconstrained, nextpnr falls back to its default 12 MHz target, and the timing report shows that domain **passing** — at a target three orders of magnitude below what the design needs.

The build is green, the constraint was never applied, and nothing in the log says so.

## Why a warning rather than an error

An indicator that reads the same whether the constraint applied or not carries no information about whether it applied. An error would break designs that legitimately carry constraints for nets synthesis removed; making the negative *observable* is enough.

## The change

Three `log_warning` calls, no behaviour change:

- **`get_nets`** — warn, naming the unmatched net or port.
- **`get_cells`** — the same defect, so the same fix.
- **`create_clock`** — warn that the period was **not** applied and that the domain keeps the default target, so the message states exactly what the silence used to hide.

A design whose selectors all resolve produces no new output.

## Notes

`.c_str(this)` follows the existing convention in `xilinx/arch.cc`; `parseXdc` is an `Arch` member, so `this` is the `BaseCtx *` that `IdString::c_str` expects.

**I could not build this locally** — this machine has `yosys` and `openFPGALoader` but not `nextpnr-xilinx` — so please treat the compile as unverified by me. The change is three log statements in existing `else` positions; if anything is wrong it will be a format specifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)