### PR TITLE
xilinx: match Vivado on LVCMOS33 pad drive and on input-pad slew

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1159,11 +1159,18 @@ struct FasmBackend
                     write_bit("LVCMOS15_SSTL15.DRIVE.I16_I_FIXED");
                 else if (iostandard == "LVCMOS18" && (drive == 12 || drive == 8))
                     write_bit("LVCMOS18.DRIVE.I12_I8");
-                else if ((iostandard == "LVCMOS33" && drive == 16) ||
-                         (iostandard == "LVTTL"    && drive == 16))
+                // prjxray-db names both patterns as covering DRIVE=12
+                // (I12_I8 and I12_I16), which cannot both be right.  The tie is
+                // broken by the four Vivado-built references in
+                // prjxray-db/artix7/harness/{arty-a7/{swbut,uart,pmod},basys3/swbut}:
+                // across all 35 LVCMOS33 output pads at Vivado's default drive
+                // the pattern is I12_I16, and I12_I8 does not occur once.  So 12
+                // belongs with 16 here, and I12_I8 is left to its other member, 8.
+                else if ((iostandard == "LVCMOS33" && (drive == 16 || drive == 12)) ||
+                         (iostandard == "LVTTL"    && (drive == 16 || drive == 12)))
                     write_bit("LVCMOS33_LVTTL.DRIVE.I12_I16");
-                else if ((iostandard == "LVCMOS33" && (drive == 8 || drive == 12)) ||
-                         (iostandard == "LVTTL"    && (drive == 8 || drive == 12)))
+                else if ((iostandard == "LVCMOS33" && drive == 8) ||
+                         (iostandard == "LVTTL"    && drive == 8))
                     write_bit("LVCMOS33_LVTTL.DRIVE.I12_I8");
                 else if ((iostandard == "LVCMOS33" && drive == 4) ||
                          (iostandard == "LVTTL"    && drive == 4))
@@ -1238,11 +1245,17 @@ struct FasmBackend
             // prjxray's DB has no SLEW.SLOW key for diff sites; emitting
             // it triggers FasmLookupError on round-trip.  Also skip if
             // is_output already covered the emit upstream.
-            if (!is_output && !is_diff && slew == "SLOW"
+            // The is_hp_bank guard is what the comment above always claimed but
+            // the condition did not check.  Measured against the Vivado-built
+            // reference in prjxray-db/artix7/harness/arty-a7/swbut/design.bit
+            // (xc7a35t, HR bank, LVCMOS33, PACKAGE_PIN + IOSTANDARD only):
+            // Vivado sets SLEW.SLOW on the 8 output pads and on none of the 9
+            // input pads, while we were setting it on all 17.  SLEW is an
+            // output-driver property; an input-only pad has no driver to slew.
+            if (!is_output && !is_diff && is_hp_bank && slew == "SLOW"
                 && iostandard != "LVDS_25" && iostandard != "TMDS_33") {
                 write_bit("LVCMOS12_LVCMOS15_LVCMOS18_LVCMOS25_LVCMOS33_LVTTL_SSTL135_SSTL15.SLEW.SLOW");
-                if (is_hp_bank)
-                    write_bit("LVCMOS12_LVCMOS15_LVCMOS18.SLEW.SLOW");
+                write_bit("LVCMOS12_LVCMOS15_LVCMOS18.SLEW.SLOW");
             }
             // HP-bank IBUF glue — fires per active input site (parallel to
             // OBUF_HP_BANK_GLUE).  For differential inputs Vivado uses a


### PR DESCRIPTION
Two IOB configuration bits diverge from Vivado on essentially every 7-series design. Neither stops the flow — both produce a valid bitstream that simply programs the pad differently — which is why nothing in the tree could see them.

**Opened as a draft on purpose: this changes the bitstream of every design with an LVCMOS33 pad, so the goldens committed in `demo-projects` no longer match and the `demos` gate will fail until they are regenerated.** That coordination is the reason not to merge this as-is. Details at the bottom.

## The oracle

`prjxray-db` already ships four Vivado-built bitstreams, and as far as I can tell nothing uses them as a reference:

```
artix7/harness/arty-a7/{swbut,uart,pmod}/design.bit
artix7/harness/basys3/swbut/design.bit
```

Each comes with a `design.dcp`, and inside it Vivado's own `top_late.xdc`. Those constrain **nothing but `PACKAGE_PIN` and `IOSTANDARD LVCMOS33`** — no `DRIVE`, no `SLEW` — so every pad sits at Vivado's defaults and a like-for-like comparison is possible. `prjxray/utils/bit2fasm.py` turns the bitstreams back into FASM.

I rebuilt a pin-identical design here (pins transcribed from the harness's own `design.txt`), emitted FASM, and diffed the IO tiles.

Two classes of difference had to be filtered out first, and they are worth writing down because they make the raw diff badly misleading:

- features whose segbits are **all negated** — `IN_TERM.NONE`, `SLEW.FAST`, `IDELMUXE3.P1`, `ISERDES.MODE.MASTER`, `ISERDES.NUM_CE.N1`, `IFF.SRTYPE.ASYNC`, `IDELAY_TYPE_FIXED` — set no bits at all, so emitting them or not cannot change the bitstream. 84 of the 251 Vivado-side lines were these.
- `always` pseudo-pips from `ppips_*.db` have no bits either, so `bit2fasm` can never recover them from a bitstream even though we emit them. All 42 of the remaining nextpnr-side lines were these (42/42 confirmed present in `ppips_*.db`).

After filtering, exactly two real differences remained.

## 1. LVCMOS33 output drive

`prjxray-db` names two distinct patterns as both covering drive 12:

```
LIOB33.IOB_Y1.LVCMOS33_LVTTL.DRIVE.I12_I8   !38_00 38_02 38_08 !38_10 38_62 39_01 !39_09 !39_15 39_63
LIOB33.IOB_Y1.LVCMOS33_LVTTL.DRIVE.I12_I16   38_00 38_02 !38_08 !38_10 38_62 39_01 !39_09 !39_15 39_63
```

Both contain `I12`, and they differ in two bits — they cannot both be right for drive 12. The vendor bitstreams break the tie. Across **all 35 LVCMOS33 output pads in the four references**, the pattern is `I12_I16`, and `I12_I8` does not occur once:

| harness | output pads | DRIVE variant |
|---|---|---|
| arty-a7/swbut | 8 | `I12_I16` ×8 |
| arty-a7/uart | 2 | `I12_I16` ×2 |
| arty-a7/pmod | 8 | `I12_I16` ×8 |
| basys3/swbut | 17 | `I12_I16` ×17 |

We were emitting `I12_I8` for the default drive, differing from Vivado in two bits on every output pad. So 12 moves in with 16, and `I12_I8` is left to its other member, 8.

## 2. Slew on input-only pads

The comment already on the input branch says Vivado emits these on **HP-bank** input pads — but the condition never tested `is_hp_bank`, so HR-bank inputs got them too. Slew is an output-driver property; an input-only pad has no driver to slew.

In the references, `SLEW.SLOW` appears exactly as many times as there are output pads and never on an input pad. On the arty-a7/swbut pinout we set it on all 17 pads where Vivado sets it on 8.

## Result

With both fixed, the IO tiles of a pin-identical build are bit-for-bit identical to Vivado's — the "nextpnr emits but Vivado does not" side of the diff is **empty**, and the only remaining Vivado-side lines are on `LIOB33_X0Y43`, a tile my design does not instantiate at all.

Independent check on a different design: `blinky-digilent-arty` targets the same board and the same two pins. Its LED pad now matches the vendor bitstream on the same physical site:

```
# Vivado harness, RIOB33_X43Y51.IOB_Y1        # blinky after this patch
LVCMOS33_LVTTL.DRIVE.I12_I16                  LVCMOS33_LVTTL.DRIVE.I12_I16
...SSTL135_SSTL15.SLEW.SLOW                   ...SSTL135_SSTL15.SLEW.SLOW
PULLTYPE.NONE                                 PULLTYPE.NONE
```

and its clk input pad (`RIOB33_X43Y75`) has no SLEW line, as in the reference.

## What I did not establish

Which pattern corresponds to which *physical* drive strength in mA. The database names both as covering 12, and I have no vendor bitstream with an explicit `DRIVE` constraint to separate them. What is measured is narrower and sufficient for this change: **at Vivado's default, the pattern is `I12_I16`.** If someone has Vivado and can build one pad each at `DRIVE 8`, `12` and `16`, that would settle the naming properly and probably deserves an upstream `prjxray-db` issue.

I also have no way to check the electrical consequence — no Vivado, and the pad difference is not something the board can report about itself.

## CI

Verified rather than assumed. Building `blinky-digilent-arty` with this patch moves its normalised hash:

```
golden : 45a57ad674cfe90aa6a2bd2ca6d6c3e416d1373ebf71139674bf3cebf984b98d
patched: 0dde63a2d3eb320cea30b32ebdc4af42a551c9c8d4ce5ecded2a4118e4665cb6
```

So the `demos` workflow fails by construction until the goldens are regenerated. Happy to do that as a paired PR against `demo-projects` whenever you want it — I just did not want to rewrite goldens unilaterally on the strength of my own patch.

A regression case (`iob-lvcmos33-drive-slew`, with an `expect.txt`/`reject.txt` pair — a "must not appear" check, which a fix that *stops* emitting a bit needs) is proposed separately against `demo-projects/regression`, per how #118 ended.

Local suite, `0.9.2` + this patch, chipdb `xc7a200tfbg484-2`:

```
  clock-srcc-bufg            ok
  bram-sdp-unused-port       ok
  bufg-fabric-driven         ok
  config-primitive-startupe2 ok
  iddr-four-iff-flops        ok
  iob-lvcmos33-drive-slew    ok
```

and the new case fails on unpatched code with both divergences reproduced, so it is a real guard and not a tautology.
