### PR TITLE
xilinx: support IDDR DDR_CLK_EDGE=SAME_EDGE_PIPELINED (fixes #65)

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1543,11 +1543,38 @@ struct FasmBackend
             else
                 write_bit("IDELMUXE3.P1");
 
-            // clock edge
+            // Clock edge.  DDR_CLK_EDGE is a three-valued parameter encoded in two bits
+            // (26_99 / 27_98 for LIOI3.ILOGIC_Y0), and the third value is the state where
+            // BOTH bits are clear:
+            //
+            //     OPPOSITE_EDGE         !26_99   27_98
+            //     SAME_EDGE              26_99  !27_98
+            //     SAME_EDGE_PIPELINED   !26_99  !27_98
+            //
+            // So SAME_EDGE_PIPELINED is expressed by writing NEITHER of the other two --
+            // there is no third feature to write, and adding one (e.g. IFF.PIPELINED) only
+            // produces a FasmLookupError, because no such key exists in any database.
+            //
+            // Our copy of prjxray-db has only the first two rows. That is not because the
+            // silicon lacks the mode but because of an omission in the fuzzer: prjxray
+            // sweeps all three values (fuzzers/035-iob-ilogic/top.py:285,
+            // fuzzers/035b-iob-iserdes/generate.py:217 emits the
+            // IFF.DDR_CLK_EDGE.SAME_EDGE_PIPELINED tag), yet
+            // fuzzers/035-iob-ilogic/tag_groups.txt lists only OPPOSITE_EDGE and
+            // SAME_EDGE in the group.  An all-bits-clear member of a group that is
+            // declared with one value missing cannot be resolved, so the row never lands
+            // in segbits.  The third row is present in the freshmakerzhao/prjxray-db fork
+            // (branch dev, artix7/segbits_lioi3.db) and agrees with the table above.
+            //
+            // Emitting nothing is safe against our own database too: no other feature on
+            // the IDDR path touches 26_99, and the ISERDES modes that set 27_98 do not
+            // apply to a plain IDDR.
             std::string edge = str_or_default(ci->params, ctx->id("DDR_CLK_EDGE"), "OPPOSITE_EDGE");
-            if (edge == "SAME_EDGE")          write_bit("IFF.DDR_CLK_EDGE.SAME_EDGE");
-            else if (edge == "OPPOSITE_EDGE") write_bit("IFF.DDR_CLK_EDGE.OPPOSITE_EDGE");
-            else log_error("unsupported clock edge parameter for cell '%s' at %s: %s. Supported are: SAME_EDGE and OPPOSITE_EDGE",
+            if (edge == "SAME_EDGE")               write_bit("IFF.DDR_CLK_EDGE.SAME_EDGE");
+            else if (edge == "OPPOSITE_EDGE")      write_bit("IFF.DDR_CLK_EDGE.OPPOSITE_EDGE");
+            else if (edge == "SAME_EDGE_PIPELINED") { /* both bits clear: write nothing */ }
+            else log_error("unsupported clock edge parameter for cell '%s' at %s: %s. Supported are: "
+                           "SAME_EDGE, OPPOSITE_EDGE and SAME_EDGE_PIPELINED",
                             ci->name.c_str(ctx), site.c_str(), edge.c_str());
 
             std::string srtype = str_or_default(ci->params, ctx->id("SRTYPE"), "SYNC");


### PR DESCRIPTION
Not a draft — unlike #119 and #120 this one is self-contained, changes no existing design's bitstream, and is verified end to end.

## The encoding

`DDR_CLK_EDGE` is a three-valued parameter in two bits, and the third value is the state where **both bits are clear**:

| value | 26_99 | 27_98 |
|---|---|---|
| `OPPOSITE_EDGE` | 0 | 1 |
| `SAME_EDGE` | 1 | 0 |
| `SAME_EDGE_PIPELINED` | **0** | **0** |

(`LIOI3.ILOGIC_Y0`; `ILOGIC_Y1` is the same shape on 26_29 / 27_28.)

So `SAME_EDGE_PIPELINED` is expressed by writing **neither** of the other two. There is no third feature to write — which is exactly why adding one (`IFF.PIPELINED`, on your `same-edge-pipelined` branch) gets a `FasmLookupError` out of `fasm2frames`: no database has that key.

Your branch's `else if` chain, which writes neither `SAME_EDGE` nor `OPPOSITE_EDGE` for the pipelined case, is therefore **right**. I said the opposite this morning in #65 — that leaving both unwritten was a defect because the feature is two-valued. It is three-valued, and both-clear is the third. Only the extra `IFF.PIPELINED` write needs to go.

## Why our database made this look impossible

I had also read the absence of the row from `segbits_lioi3.db` as "the silicon has no such bit". Also wrong. It is an omission in the fuzzer:

* `fuzzers/035-iob-ilogic/top.py:285` sweeps all three values;
* `fuzzers/035b-iob-iserdes/generate.py:217` generates the `IFF.DDR_CLK_EDGE.SAME_EDGE_PIPELINED` tag;
* but `fuzzers/035-iob-ilogic/tag_groups.txt` declares the group with only two members:

```
IOI3.ILOGIC_Y0.IFF.DDR_CLK_EDGE.OPPOSITE_EDGE IOI3.ILOGIC_Y0.IFF.DDR_CLK_EDGE.SAME_EDGE
```

An **all-bits-clear** member of a group declared one value short cannot be resolved by `dbfixup.py`'s `group_tags`, so the row never reaches segbits. It is the same trap in miniature: a value encoded as the absence of bits is invisible to anything that only looks for bits.

Independent confirmation that the row is real: the `freshmakerzhao/prjxray-db` fork (branch `dev`, `artix7/segbits_lioi3.db`) carries it, and it matches the table above exactly:

```
LIOI3.ILOGIC_Y0.IFF.DDR_CLK_EDGE.SAME_EDGE_PIPELINED !26_99 !27_98
```

## Safety against our own database

Writing nothing cannot collide: no other feature on the IDDR path touches `26_99`, and the ISERDES modes that set `27_98` do not apply to a plain IDDR. Checked by enumerating every `LIOI3.ILOGIC_Y0.*` feature that mentions either bit.

## Verified

IDDR at `SAME_EDGE_PIPELINED`, `xc7a200tfbg484-2`:

```
nextpnr-xilinx    exit 0                        (previously log_error -- that is #65)
FASM              0 DDR_CLK_EDGE lines, IDDR.IN_USE present
fasm2frames       exit 0, 22698060 bytes
```

The last line is the point: that is the step where the `same-edge-pipelined` branch fails and this does not.

## What I have not verified

That the resulting hardware actually pipelines Q1 by one clock. That needs an instrument I do not yet trust — see the retraction I posted on #119 today about exactly this. What is established here is the encoding and that the flow completes correctly; the behavioural check is separate and I would not claim it.

## Follow-up for prjxray

The missing row is worth fixing at source: one added name in `fuzzers/035-iob-ilogic/tag_groups.txt` plus a re-run. No nextpnr change depends on it, since the correct emission is no emission, but the database would stop lying about the parameter's arity — and arity being wrong in the database is what sent me down the wrong path twice today. Happy to file that upstream if you would like it filed.