### PR TITLE
xilinx: emit IFF.INV_OCLK and OSERDES.TRISTATE_WIDTH.W4

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1649,6 +1649,14 @@ struct FasmBackend
 #endif
             write_bit("SRTYPE.SYNC");
             write_bit("TSRTYPE.SYNC");
+            // TRISTATE_WIDTH is a two-valued parameter whose W1 state is encoded as the
+            // absence of bits, so only W4 appears in segbits (32_90 on OLOGIC_Y0).  The
+            // fuzzer sweeps both (036-iob-ologic/generate.py:106-110) and 036-iob-ologic/
+            // top.py:71-79 picks 4 exactly when DATA_WIDTH==4 with both rates DDR.  Never
+            // writing it left every OSERDESE2 programmed as TRISTATE_WIDTH=1, silently
+            // overriding the cell's own parameter -- which defaults to 4 in the library.
+            if (int_or_default(ci->params, ctx->id("TRISTATE_WIDTH"), 4) == 4)
+                write_bit("TRISTATE_WIDTH.W4");
             if (is_slave) write_bit("SERDES_MODE.SLAVE");
 
             pop();
@@ -1665,7 +1673,17 @@ struct FasmBackend
                           !bool_or_default(ci->params, ctx->id("SRVAL_Q" + std::to_string(i)), false));
             }
             write_bit("IFF.ZINV_C", !bool_or_default(ci->params, ctx->id("IS_CLK_INVERTED"), false));
-            write_bit("IFF.ZINV_OCLK", !bool_or_default(ci->params, ctx->id("IS_OCLK_INVERTED"), false));
+            // INV_OCLK (28_124) and ZINV_OCLK (28_64) are two DISTINCT physical bits, not
+            // one bit and its complement -- they are absent from
+            // fuzzers/035-iob-ilogic/tag_groups.txt, so dbfixup never collapsed them.
+            // The fuzzer sets them as exact complements (035-iob-ilogic/generate.py:180-184:
+            // INV_OCLK = IS_OCLK_INVERTED, ZINV_OCLK = !IS_OCLK_INVERTED), so exactly one
+            // of the two must always be set.  Writing only the Z half meant that
+            // IS_OCLK_INVERTED=TRUE emitted NEITHER bit, leaving the OCLK inverter in an
+            // unprogrammed state that corresponds to no value of the parameter.
+            bool oclk_inv = bool_or_default(ci->params, ctx->id("IS_OCLK_INVERTED"), false);
+            write_bit("IFF.INV_OCLK", oclk_inv);
+            write_bit("IFF.ZINV_OCLK", !oclk_inv);
 
             std::string iobdelay = str_or_default(ci->params, ctx->id("IOBDELAY"), "NONE");
             write_bit("IFFDELMUXE3.P0", (iobdelay == "IFD"));


### PR DESCRIPTION
Two IOLOGIC features that `prjxray-db` documents and we never write. Found by enumerating every segbits feature for the IOI3 tiles and diffing that set against what `fasm.cc` emits.

Both are the same trap, which is worth naming because it has now bitten this codebase four times in one day: **a value encoded as the absence of bits is invisible to a search that looks for bits.**

## `IFF.INV_OCLK`

`INV_OCLK` (28_124) and `ZINV_OCLK` (28_64) are **two distinct physical bits**, not one bit and its complement. They are absent from `fuzzers/035-iob-ilogic/tag_groups.txt`, so `dbfixup` never collapsed them into a ± pair the way it did for `IDELMUXE3` (`P0 29_101` / `P1 !29_101`).

The fuzzer sets them as exact complements (`035-iob-ilogic/generate.py:180-184`):

```python
add_site_tag(site, 'IFF.INV_OCLK',   d['IS_OCLK_INVERTED'])
add_site_tag(site, 'IFF.ZINV_OCLK', not d['IS_OCLK_INVERTED'])
```

so exactly one of the two is always set. We wrote only the Z half, conditionally:

```cpp
write_bit("IFF.ZINV_OCLK", !bool_or_default(..., "IS_OCLK_INVERTED", false));
```

With `IS_OCLK_INVERTED=TRUE`, `write_bit(x, false)` emits nothing — so **neither** bit is set, and the OCLK inverter sits in a state that corresponds to no value of the parameter.

## `OSERDES.TRISTATE_WIDTH.W4`

Two-valued, with `W1` encoded as the absence of bits, so only `W4` reaches segbits (`32_90` on `OLOGIC_Y0`, `33_37` on `Y1`). The fuzzer sweeps both (`036-iob-ologic/generate.py:106-110`).

We never emitted it, so **every OSERDESE2 was programmed `TRISTATE_WIDTH=1`** regardless of the cell's own parameter — which defaults to 4 in the library and does survive synthesis (it is present in the netlist JSON).

## Verified

DDR OSERDESE2 at `TRISTATE_WIDTH=4`, `xc7a200tfbg484-2`:

```
nextpnr-xilinx  exit 0
FASM            LIOI3_X0Y233.OLOGIC_Y1.OSERDES.TRISTATE_WIDTH.W4
fasm2frames     exit 0, 22698060 bytes
```

Existing regression cases all still pass (`clock-srcc-bufg`, `bram-sdp-unused-port`, `bufg-fabric-driven`, `config-primitive-startupe2`, `iddr-four-iff-flops`).

## Deliberately left out

A third gap from the same enumeration: OLOGIC `TDDR.SRUSED` (`33_89`), the T-register twin of `ODDR.SRUSED` which we *do* write unconditionally in the OSERDESE2 branch. Fixing it needs a judgement about when the T register should take SR, and I would rather not guess — happy to add it if you have a view.

## Relationship to the other open PRs

Independent of #120 (IOB pad electrical config) and #121 (`SAME_EDGE_PIPELINED`). Unlike #120 this does not disturb the demo goldens for any design that has no OSERDESE2 or OCLK inversion.