### PR TITLE
xilinx: accept IBUFGDS as an alias of IBUFDS (fixes #74)

### DIFF
--- a/xilinx/cells.cc
+++ b/xilinx/cells.cc
@@ -134,7 +134,11 @@ std::unique_ptr<CellInfo> create_cell(Context *ctx, IdString type, IdString name
         add_port("IBUFDISABLE", PORT_IN);
         add_port("INTERMDISABLE", PORT_IN);
         add_port("O", PORT_OUT);
-    } else if (type == ctx->id("IBUFDS")) {
+    } else if (type == ctx->id("IBUFDS") || type == ctx->id("IBUFGDS")) {
+        // IBUFGDS is the legacy clock-capable spelling of IBUFDS. On 7-series
+        // they are the same primitive -- UG953 documents IBUFGDS only as a
+        // Spartan-6-and-earlier name, and Vivado still accepts it -- so it is
+        // handled as an alias rather than as a separate cell. (fixes #74)
         add_port("I", PORT_IN);
         add_port("IB", PORT_IN);
         add_port("O", PORT_OUT);

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -139,7 +139,8 @@ void XC7Packer::decompose_iob(CellInfo *xil_iob, bool is_hr, const std::string &
             subcells.push_back(obuf);
     }
 
-    bool is_diff_ibuf = xil_iob->type == ctx->id("IBUFDS") || xil_iob->type == ctx->id("IBUFDS_INTERMDISABLE");
+    bool is_diff_ibuf = xil_iob->type == ctx->id("IBUFDS") || xil_iob->type == ctx->id("IBUFGDS") ||
+                        xil_iob->type == ctx->id("IBUFDS_INTERMDISABLE");
     bool is_diff_iobuf = xil_iob->type == ctx->id("IOBUFDS") || xil_iob->type == ctx->id("IOBUFDS_DCIEN");
     bool is_diff_out_iobuf = xil_iob->type == ctx->id("IOBUFDS_DIFF_OUT") ||
                              xil_iob->type == ctx->id("IOBUFDS_DIFF_OUT_DCIEN") ||
@@ -450,6 +451,8 @@ void XC7Packer::pack_io()
     hriobuf_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
     hriobuf_rules[ctx->id("IBUFDS")] = hriobuf_rules[ctx->id("IBUF")];
     hriobuf_rules[ctx->id("IBUFDS")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
+    // IBUFGDS: legacy clock-capable spelling of IBUFDS, same primitive on 7-series (#74)
+    hriobuf_rules[ctx->id("IBUFGDS")] = hriobuf_rules[ctx->id("IBUFDS")];
 
     hpiobuf_rules[ctx->id("OBUF")].new_type = ctx->id("IOB18_OUTBUF_DCIEN");
     hpiobuf_rules[ctx->id("OBUF")].port_xform[ctx->id("I")] = ctx->id("IN");
@@ -466,6 +469,7 @@ void XC7Packer::pack_io()
     hpiobuf_rules[ctx->id("IBUFDS_INTERMDISABLE_INT")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
     hpiobuf_rules[ctx->id("IBUFDS")] = hpiobuf_rules[ctx->id("IBUF")];
     hpiobuf_rules[ctx->id("IBUFDS")].port_xform[ctx->id("IB")] = ctx->id("DIFFI_IN");
+    hpiobuf_rules[ctx->id("IBUFGDS")] = hpiobuf_rules[ctx->id("IBUFDS")];
 
     // Special xform for OBUFx and IBUFx.
     std::unordered_map<IdString, XFormRule> rules;

--- a/xilinx/pins.cc
+++ b/xilinx/pins.cc
@@ -700,6 +700,7 @@ void get_top_level_pins(Context *ctx, std::unordered_map<IdString, std::unordere
     toplevel_pins[ctx->id("IBUFE3")] = {ctx->id("I")};
 
     toplevel_pins[ctx->id("IBUFDS")] = {ctx->id("I"), ctx->id("IB")};
+    toplevel_pins[ctx->id("IBUFGDS")] = {ctx->id("I"), ctx->id("IB")};
     toplevel_pins[ctx->id("IBUFDS_DIFF_OUT")] = {ctx->id("I"), ctx->id("IB")};
     toplevel_pins[ctx->id("IBUFDS_DIFF_OUT_IBUFDISABLE")] = {ctx->id("I"), ctx->id("IB")};
     toplevel_pins[ctx->id("IBUFDS_DIFF_OUT_INTERMDISABLE")] = {ctx->id("I"), ctx->id("IB")};


### PR DESCRIPTION
`IBUFGDS` is the legacy clock-capable spelling of `IBUFDS`. On 7-series they are the same primitive — UG953 documents `IBUFGDS` as a Spartan-6-and-earlier name, and Vivado still accepts it — but the string appears **nowhere** in this tree, so any design instantiating it dies at placement:

```
ERROR: Unable to place cell 'u_clkbuf', no Bels remaining of type 'IBUFGDS'
```

No site is missing and no database entry is missing. It was purely a naming gap. `IBUFDS` is recognised in four places, and `IBUFGDS` is now recognised alongside it in each:

| file | what |
|---|---|
| `cells.cc:137` | port list for the cell type |
| `pins.cc:703` | `toplevel_pins` entry |
| `pack_io_xc7.cc:142` | the `is_diff_ibuf` test |
| `pack_io_xc7.cc:455,472` | HR and HP bank rule maps |

## How I ran into it

I was building a JTAG-readable IDDR test instrument for #114 — the AX7203's system clock is a differential pair, and `IBUFGDS` is the natural way to buffer it. So this is verified by a design that actually needs it rather than by a synthetic case.

## Verified

`xc7a200tfbg484-2`. Before: the placement error above. After:

```
nextpnr-xilinx  exit 0, 2370-line FASM
FASM            RIOB33_X105Y123.IOB_Y0.LVDS_25_SSTL135_SSTL15.IN_DIFF
                RIOB33_X105Y123.IOB_Y1.LVDS_25_SSTL135_SSTL15.IN_DIFF
                HCLK_IOI3_X263Y130.ONLY_DIFF_IN_USE
```

The pair is configured as a real differential input, not merely placed.

Existing regression cases all still pass (`clock-srcc-bufg`, `bram-sdp-unused-port`, `bufg-fabric-driven`, `config-primitive-startupe2`, `iddr-four-iff-flops`).

## Left out deliberately

`IBUFG`, the single-ended counterpart, is missing for the same reason and needs the same treatment against `IBUF`. Different path, so I did not fold it in — happy to follow up if you want it in the same PR.