### PR TITLE
xilinx: don't assert IFF.SRTYPE on the ILOGIC combinatorial pass-through

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -163,7 +163,13 @@ struct FasmBackend
                                      // without it the routethru never propagates
                                      "IDELAY_Y" + i + ".IDELAY_TYPE_FIXED",
                                      "ILOGIC_Y" + i + ".IDELMUXE3.P1",
-                                     "ILOGIC_Y" + i + ".IFF.SRTYPE.ASYNC",
+                                     // IFF.SRTYPE deliberately NOT asserted here: this is
+                                     // the COMBINATORIAL pass-through, and the IFF's set/reset
+                                     // type is no part of it.  SRTYPE.ASYNC is an all-negated
+                                     // feature (!29_67), so asserting it sets nothing but does
+                                     // actively CLEAR the bit -- which collides with an IDDR on
+                                     // the same ILOGIC site emitting IFF.SRTYPE.SYNC, and
+                                     // fasm2frames then refuses the design outright.
                                      "ILOGIC_Y" + i + ".ISERDES.MODE.MASTER",
                                      "ILOGIC_Y" + i + ".ISERDES.NUM_CE.N1",
                                      "ILOGIC_Y" + i + ".ZINV_D"
@@ -212,7 +218,8 @@ struct FasmBackend
                                 // input): IDELMUXE3.P1 = direct D path
                                 "IDELAY_Y" + i + ".IDELAY_TYPE_FIXED",
                                 "ILOGIC_Y" + i + ".IDELMUXE3.P1",
-                                "ILOGIC_Y" + i + ".IFF.SRTYPE.ASYNC",
+                                // see the LIOI3 block above: IFF.SRTYPE is not part of a
+                                // combinatorial pass-through and collides with an IDDR here
                                 "ILOGIC_Y" + i + ".ISERDES.MODE.MASTER",
                                 "ILOGIC_Y" + i + ".ISERDES.NUM_CE.N1",
                                 "ILOGIC_Y" + i + ".ZINV_D"


### PR DESCRIPTION
An input pad whose ILOGIC hosts an IDDR **and** whose combinatorial output also feeds fabric logic currently produces FASM that cannot be assembled at all:

```
FasmInconsistentBits: FASM line "RIOI3_X105Y115.ILOGIC_Y1.IFF.SRTYPE.ASYNC"
wanted to clear bit (4207772, 31, 28) but was set by FASM line
"RIOI3_X105Y115.ILOGIC_Y1.IFF.SRTYPE.SYNC"
```

`fasm2frames` exits 1 and writes nothing — no bitstream.

## Why

Two paths write the same site. The IDDR branch writes `IFF.SRTYPE.SYNC` from the cell parameter. The routethru pseudo-pip for the pad's O path (`IOI_ILOGIC{i}_O ← IOI_ILOGIC{i}_D`) writes a "full ILOGIC pass-through config" block that includes `IFF.SRTYPE.ASYNC`.

The pass-through is **combinatorial**; the IFF's set/reset type is no part of it. And the entry is not the harmless default it looks like — `SRTYPE.ASYNC` is an all-negated feature (`!29_67`), so asserting it sets nothing but does actively **clear** the bit, which is what collides with a real IFF on the same site.

Removed from both the LIOI3 and RIOI blocks.

## Blast radius: measured, not argued

For a design with a pass-through pad and no IDDR, the frames are **byte-identical** before and after:

```
$ cmp withfix.frames nofix.frames   # 22698060 bytes each
(no output)
```

Nothing writes `29_67` in that case either way, so the bit stays 0 exactly as before. **This does not move any demo golden** — unlike #120, it should sail through the demos gate.

## Minimal reproducer

`xc7a200tfbg484-2`, one pad feeding both an IDDR and an ordinary fabric flop:

```verilog
IDDR #(.SRTYPE("SYNC")) u (.C(clk), .CE(1'b1), .D(d), .R(1'b0), .S(1'b0), .Q1(q1), .Q2(q2));
reg r; always @(posedge clk) r <= d;    // the pad's O path, used as well
```

| | SRTYPE lines on the site | fasm2frames |
|---|---|---|
| before | 2 (`SYNC` + `ASYNC`) | exit 1, **0 bytes** |
| after | 1 (`SYNC`) | exit 0, 22698060 bytes |

## How I hit it

Building a JTAG-readable IDDR instrument for #114. It needs the raw pad value alongside the DDR-captured one as a control — which is exactly the pattern that triggers this. Wanting both the DDR capture and the raw signal from one pin seems a common enough thing to want.

A regression case for `demo-projects/regression` would fit the existing pattern here (build-stopping, so the plain non-empty-FASM criterion catches it); happy to add it once you have a view on this patch.