### PR TITLE
ci(demos): actually run the PR's nextpnr-xilinx, and assert that we do

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -116,6 +116,17 @@ jobs:
           export PRJXRAY_DB_DIR="$GITHUB_WORKSPACE/nextpnr-xilinx/xilinx/external/prjxray-db"
           export PATH="$GITHUB_WORKSPACE/build-pr:$PATH"
           nix develop ./toolchain-nix --command bash -euxo pipefail <<'EOF'
+            # nix develop prepends the devshell's own store paths, so the
+            # toolchain's pinned nextpnr-xilinx shadows the one we just built
+            # from this PR -- the export above is undone the moment we enter
+            # the shell.  Re-prepend it here, inside, and prove which binary
+            # is actually being used.
+            export PATH="$GITHUB_WORKSPACE/build-pr:$PATH"
+            command -v nextpnr-xilinx
+            case "$(command -v nextpnr-xilinx)" in
+              "$GITHUB_WORKSPACE/build-pr/"*) ;;
+              *) echo "::error::demos gate is not using this PR's nextpnr-xilinx"; exit 1 ;;
+            esac
             normhash() { python3 demo-projects/.github/scripts/normbit.py "$1"; }
             for p in $PROJECTS; do
               if ls "demo-projects/$p"/*.bit >/dev/null 2>&1; then


### PR DESCRIPTION
The demos gate builds `nextpnr-xilinx` from the PR into `build-pr` and exports `PATH` to put it first — but that export happens **outside** the `nix develop` call. `nix develop` prepends the devshell's own store paths, so the toolchain's pinned `nextpnr-xilinx-0.9.2` wins and the PR's binary is never executed. Only `bbasm` is, because that one is invoked by explicit path.

The result is a gate that is green by construction for any change to nextpnr-xilinx itself — the one thing it exists to test.

## Evidence

From the artix7 leg of #120:

```
building '/nix/store/irw70vklrzphnargzcxp4xyzk1rdaylx-nextpnr-xilinx-0.9.2.drv'...   <- devshell's
+ cmake --build build-pr --parallel 4                                                <- the PR's, unused
```

And the deduction that closes it. #120 changes the IOB drive and slew bits, so it moves the normalised hash of `blinky-digilent-arty` — measured locally:

```
golden : 45a57ad674cfe90aa6a2bd2ca6d6c3e416d1373ebf71139674bf3cebf984b98d
patched: 0dde63a2d3eb320cea30b32ebdc4af42a551c9c8d4ce5ecded2a4118e4665cb6
```

`blinky-digilent-arty` is in the artix7 leg's subset, and that leg **passed**. Two measurements, one conclusion: the bitstream it compared was not built by the PR.

## The fix

Re-prepend inside the shell, where it survives.

And then assert it. A silent regression here is precisely the failure mode being fixed, so the gate now prints which `nextpnr-xilinx` resolved and fails loudly if it is not the PR's — rather than passing vacuously if this ever comes undone again. An existence check whose negative is unobservable carries no information; the same applies to a gate whose bypass is invisible.

## Expect red

This will turn some currently-green PRs red, which is the point. **#120 in particular should go red** until the demo goldens are regenerated — I flagged that in its description and it is now enforced rather than merely stated.

I would rather hand you a gate that fails honestly on my own PR than one that waves it through.