### PR TITLE
xilinx: emit ZINV_REGCLKARDRCLK / ZINV_REGCLKB for registered BRAM outputs

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2197,6 +2197,23 @@ struct FasmBackend
                 write_bit("ZINV_" + pn,
                           !bool_or_default(ci->params, ctx->id("IS_" + pn + "_INVERTED"), false));
             }
+            // REGCLKARDRCLK and REGCLKB are SITE pins, not RAMB18E1/RAMB36E1 cell
+            // ports, so they are absent from invertible_pins (pins.cc lists eight
+            // pins for these types and neither of those two).  The `pn ==
+            // "REGCLKARDRCLK"` / `pn == "REGCLKB"` guards above therefore never
+            // fire, and the bits were emitted nowhere at all.
+            //
+            // prjxray's fuzzer states the rule (fuzzers/025-bram-config/generate.py):
+            // with DO*_REG == 1 the output-register clock FOLLOWS the corresponding
+            // data clock, and with DO*_REG == 0 it is always inverted -- i.e. tag 0,
+            // which is the bit clear, which is what emitting nothing already gives.
+            // So only the registered case needs anything written.
+            if (bool_or_default(ci->params, ctx->id("DOA_REG"), false))
+                write_bit("ZINV_REGCLKARDRCLK",
+                          !bool_or_default(ci->params, ctx->id("IS_CLKARDCLK_INVERTED"), false));
+            if (bool_or_default(ci->params, ctx->id("DOB_REG"), false))
+                write_bit("ZINV_REGCLKB",
+                          !bool_or_default(ci->params, ctx->id("IS_CLKBWRCLK_INVERTED"), false));
             // golden per-half defaults (dcp2fasm campaign):
             if (str_or_default(ci->params, ctx->id("RDADDR_COLLISION_HWCONFIG"), "DELAYED_WRITE") == "PERFORMANCE")
                 write_bit("RDADDR_COLLISION_HWCONFIG_PERFORMANCE");


### PR DESCRIPTION
The two output-register clock inverter bits are emitted nowhere at all. The code that looks like it handles them cannot run:

```cpp
for (auto &invpin : invertible_pins[X_ORIG_TYPE]) {
    std::string pn = invpin.str(ctx);
    if ((pn == "RSTREGARSTREG" || pn == "REGCLKARDRCLK") && !DOA_REG) continue;
    if ((pn == "RSTREGB"       || pn == "REGCLKB")       && !DOB_REG) continue;
    write_bit("ZINV_" + pn, ...);
}
```

`REGCLKARDRCLK` and `REGCLKB` are **site** pins, not `RAMB18E1`/`RAMB36E1` cell ports, so they are absent from `invertible_pins` — `pins.cc` lists eight pins for these types (`CLKARDCLK`, `CLKBWRCLK`, `ENARDEN`, `ENBWREN`, `RSTRAMARSTRAM`, `RSTRAMB`, `RSTREGARSTREG`, `RSTREGB`) and neither of those two is among them. So both `pn ==` tests are dead code and the bits they guard were never written by anything.

## The rule

From the fuzzer that generated the database, `fuzzers/025-bram-config/generate.py:40-55`:

```python
elif param == 'IS_REGCLKARDRCLK_INVERTED':
    if verilog.parsei(ps['DOA_REG']):
        # When DOA_REG == 1, REGCLKARDRCLK follows the CLKARDCLK setting.
        tag = 1 ^ verilog.parsei(actual_ps['IS_CLKARDCLK_INVERTED'])
    else:
        # When DOA_REG == 0, REGCLKARDRCLK is always inverted.
        tag = 0
```

Tag 0 means the bit clear, which is what emitting nothing already achieves — so only the **registered** case needs anything written. That is why this has gone unnoticed: it is invisible unless a design actually uses the BRAM output registers.

The bits exist in the database: `BRAM_L.RAMB18_Y0.ZINV_REGCLKARDRCLK 27_104`, `.ZINV_REGCLKB 27_108` (and the Y1 pair), same in `segbits_bram_r.db`.

## Verified

`xc7a200tfbg484-2`, a directly instantiated `RAMB18E1` at `DOA_REG=1, DOB_REG=1`, neither clock inverted:

| | emitted on the BRAM |
|---|---|
| before | `ZINV_CLKARDCLK` `ZINV_CLKBWRCLK` `ZINV_ENARDEN` `ZINV_ENBWREN` |
| after | …plus `ZINV_REGCLKARDRCLK` and `ZINV_REGCLKB` |

`fasm2frames` exit 0, 22698060 bytes.

**No-op for the unregistered case, measured rather than argued:** the `bram-sdp-unused-port` regression design (`DOA_REG = DOB_REG = 0`) produces a **byte-identical** FASM before and after. All five existing regression cases still pass. So this should not move any demo golden.

## What I have not established

Hardware validation. I have no Vivado, and no artix7 vendor bitstream containing a BRAM with registered outputs — the four references shipped in `prjxray-db/artix7/harness/` contain no BRAM at all. The rule above comes from the fuzzer that generated the database, not from a vendor bitstream, so if you want a stronger check before merging, one Vivado build with `DOA_REG=1` would settle it outright.

I am flagging that explicitly because I tested three database-derived candidates tonight and two of them did **not** survive an A/B against the actual tool — reading the fuzzer correctly is not by itself sufficient. This one does survive it, and the dead-code half of the argument is structural rather than inferred, but the polarity ultimately rests on the fuzzer comment.