### PR TITLE
xilinx: stop holding the MMCM in reset (fixes #79)

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2349,9 +2349,12 @@ struct FasmBackend
         push(get_tile_name(ci->bel.tile));
         push("PLLE2_ADV");
         write_bit("IN_USE");
-        // FIXME: should be INV not ZINV (XRay error?)
-        write_bit("ZINV_PWRDWN", bool_or_default(ci->params, ctx->id("IS_PWRDWN_INVERTED"), false));
-        write_bit("ZINV_RST", bool_or_default(ci->params, ctx->id("IS_RST_INVERTED"), false));
+        // ZINV_x is asserted when the signal is NOT inverted.  prjxray's CMT fuzzers
+        // tag it as `add_site_tag(site, 'ZINV_' + reg, 1 ^ IS_<reg>_INVERTED)`
+        // (031-cmt-mmcm/generate.py:46, 032-cmt-pll), the same convention as every
+        // other ZINV_ in this file.  INV_CLKINSEL really is direct (invert=0 there).
+        write_bit("ZINV_PWRDWN", !bool_or_default(ci->params, ctx->id("IS_PWRDWN_INVERTED"), false));
+        write_bit("ZINV_RST", !bool_or_default(ci->params, ctx->id("IS_RST_INVERTED"), false));
         write_bit("INV_CLKINSEL", bool_or_default(ci->params, ctx->id("IS_CLKINSEL_INVERTED"), false));
         write_pll_clkout("DIVCLK", ci);
         write_pll_clkout("CLKFBOUT", ci);
@@ -2492,11 +2495,14 @@ struct FasmBackend
         push(get_tile_name(ci->bel.tile));
         push("MMCME2_ADV");
         write_bit("IN_USE");
-        // FIXME: should be INV not ZINV (XRay error?)
-        write_bit("ZINV_PWRDWN", bool_or_default(ci->params, id_IS_PWRDWN_INVERTED, false));
-        write_bit("ZINV_RST", bool_or_default(ci->params, id_IS_RST_INVERTED, false));
-        write_bit("ZINV_PSEN", bool_or_default(ci->params, id_IS_PSEN_INVERTED, false));
-        write_bit("ZINV_PSINCDEC", bool_or_default(ci->params, id_IS_PSINCDEC_INVERTED, false));
+        // ZINV_x is asserted when the signal is NOT inverted.  prjxray's CMT fuzzers
+        // tag it as `add_site_tag(site, 'ZINV_' + reg, 1 ^ IS_<reg>_INVERTED)`
+        // (031-cmt-mmcm/generate.py:46, 032-cmt-pll), the same convention as every
+        // other ZINV_ in this file.  INV_CLKINSEL really is direct (invert=0 there).
+        write_bit("ZINV_PWRDWN", !bool_or_default(ci->params, id_IS_PWRDWN_INVERTED, false));
+        write_bit("ZINV_RST", !bool_or_default(ci->params, id_IS_RST_INVERTED, false));
+        write_bit("ZINV_PSEN", !bool_or_default(ci->params, id_IS_PSEN_INVERTED, false));
+        write_bit("ZINV_PSINCDEC", !bool_or_default(ci->params, id_IS_PSINCDEC_INVERTED, false));
         write_bit("INV_CLKINSEL", bool_or_default(ci->params, id_IS_CLKINSEL_INVERTED, false));
         write_mmcm_clkout("DIVCLK", ci);
         write_mmcm_clkout("CLKFBOUT", ci);

--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -209,6 +209,12 @@ void XC7Packer::pack_plls()
                 NetInfo *nn = get_net_or_empty(ci, ctx->id(p));
                 if (nn != nullptr && (nn->name == gnd || nn->name == vcc)) {
                     disconnect_port(ctx, ci, ctx->id(p));
+                    // pack_constants (pack.cc) fabricates IS_<pin>_INVERTED = 1 when it
+                    // ties an unconnected invertible pin to VCC -- it is a routing
+                    // optimisation, not a netlist attribute.  Having just removed the
+                    // pin, drop the parameter with it, or fasm.cc reads an inversion
+                    // for a pin that is connected to nothing.
+                    ci->params.erase(ctx->id("IS_" + p + "_INVERTED"));
                     ++n;
                 }
             }
@@ -217,6 +223,7 @@ void XC7Packer::pack_plls()
                     NetInfo *nn = get_net_or_empty(ci, ctx->id(p));
                     if (nn != nullptr && (nn->name == gnd || nn->name == vcc)) {
                         disconnect_port(ctx, ci, ctx->id(p));
+                        ci->params.erase(ctx->id("IS_" + p + "_INVERTED"));
                         ++n;
                     }
                 }


### PR DESCRIPTION
An `MMCME2_ADV` whose `RST` is driven by a real net comes out with `ZINV_RST` **clear**, which per prjxray means `IS_RST_INVERTED` — a hardware inverter on the reset input. An ordinary active-high reset held low then presents `RST=1` to the MMCM for ever, so it never leaves reset and never locks. That is this issue's "does not lock, output clock erratic".

## Why it survived, and why the obvious fix makes it worse

Two mistakes were lined up so that they cancelled in the common case.

**1. Polarity.** `ZINV_x` is asserted when the signal is **not** inverted — prjxray's fuzzers tag it as `1 ^ IS_<reg>_INVERTED` (`031-cmt-mmcm/generate.py:46`, `032-cmt-pll`), and it is how every other `ZINV_` in `fasm.cc` is written (`IFF.ZINV_C`, `ZINV_D`, `ZINV_CE0`, `ZINV_ODATAIN`, …). `write_pll`/`write_mmcm` wrote the un-negated value under a comment that guessed the database was wrong:

```cpp
// FIXME: should be INV not ZINV (XRay error?)
write_bit("ZINV_RST", bool_or_default(ci->params, id_IS_RST_INVERTED, false));
```

The database is right. The negation was missing.

**2. A fabricated parameter masking it.** `pack_constants` (`pack.cc:958`) sets `IS_<pin>_INVERTED = 1` when it ties an unconnected invertible pin to VCC — a routing optimisation, not a netlist attribute. The const-tie cleanup in `pack_clocking_xc7.cc` then disconnects that pin but left the parameter behind, so `fasm.cc` read an inversion for a pin connected to nothing.

For const-tied pins that spurious `TRUE` cancelled mistake 1 **exactly**. Which is why a default MMCM looks healthy, and why only designs with a real reset net are broken.

I know the trap is real because I fell in it: I wrote the negation-only patch first, A/B'd it, and found it **removed** all four bits from the working case. I discarded it and reported it as a failed hypothesis before finding the second half.

## Measured, both directions

`xc7a200tfbg484-2`:

| | before | after |
|---|---|---|
| `RST` from a net | `PWRDWN PSEN PSINCDEC` | **+ `ZINV_RST`** |
| `RST` const-tied | all four | all four |

and the whole `MMCME2_ADV` FASM block for the const-tied design is **byte-identical** to unpatched output. So the previously-working case does not move, and this should not shift any demo golden.

All five existing regression cases still pass.

## What I have not established

Hardware validation. No Vivado here, and no vendor artix7 bitstream containing an MMCM or PLL — the four references shipped in `prjxray-db/artix7/harness/` have none, so the differential oracle that settled the IOB questions in #120 cannot reach this one.

The causal step *"inverted RST ⇒ `LOCKED` never asserts"* is read off the fuzzer semantics and the primitive's behaviour. **What is measured** is the emission asymmetry between a const-tied and a net-driven reset, and that the asymmetry is gone.

@hansemro / anyone on this thread with the board and a failing design: this is cheap to falsify — build with and without, and see whether `LOCKED` comes up. If it does not, say so and I will withdraw it; I retracted a hardware claim on #119 yesterday for exactly this kind of gap and would rather do it early.

## Also worth a look, separately

`pack.cc:958` fabricating `IS_<pin>_INVERTED` is a foot-gun for any pass that later removes the pin. This PR fixes the one consumer that tripped over it; a comment at the source would stop the next one. I left the parameter-erase local to the clocking cleanup rather than changing `pack_constants`, since that is the conservative half.