### PR TITLE
xilinx: emit OLOGIC IS_CLKDIV_INVERTED for OSERDESE2

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1691,6 +1691,13 @@ struct FasmBackend
             // overriding the cell's own parameter -- which defaults to 4 in the library.
             if (int_or_default(ci->params, ctx->id("TRISTATE_WIDTH"), 4) == 4)
                 write_bit("TRISTATE_WIDTH.W4");
+            // An explicitly requested CLKDIV inversion on an OSERDESE2 was discarded:
+            // the bit is documented (OLOGIC_Y*.IS_CLKDIV_INVERTED) and was written
+            // nowhere.  It sits on the OLOGIC, not inside the OSERDES prefix.
+            pop();
+            write_bit("IS_CLKDIV_INVERTED",
+                      bool_or_default(ci->params, ctx->id("IS_CLKDIV_INVERTED"), false));
+            push("OSERDES");
             if (is_slave) write_bit("SERDES_MODE.SLAVE");
 
             pop();


### PR DESCRIPTION
An `OSERDESE2` instantiated with `.IS_CLKDIV_INVERTED(1'b1)` has the request **silently discarded**. The parameter survives synthesis and reaches the backend, `CLKDIV` is routed to the site, and the bit is written nowhere — `grep IS_CLKDIV_INVERTED xilinx/*.cc` returns no emitter.

The bit is documented: `OLOGIC_Y*.IS_CLKDIV_INVERTED` in `segbits_rioi3.db` and its LIOI3 twin. It sits on the OLOGIC rather than inside the `OSERDES` prefix, hence the `pop()`/`push()` around the write.

## Verified

`xc7a200tfbg484-2`, an OSERDESE2 at `IS_CLKDIV_INVERTED=1` with CLKDIV connected:

| | |
|---|---|
| before | no such line in the FASM |
| after | `LIOI3_TBYTETERM_X0Y237.OLOGIC_Y1.IS_CLKDIV_INVERTED` |

All five existing regression cases still pass. A design that does not ask for the inversion is unaffected — `write_bit()` with a false condition emits nothing — so no demo golden moves.

## Deliberately not in this patch

The same sweep found `ISERDES.DYN_CLK_INV_EN` and `ISERDES.DYN_CLKDIV_INV_EN` in the same state: documented in the database, select signals (`DYNCLKSEL` / `DYNCLKDIVSEL`) routed into the site by the packer, and the enabling feature never emitted — so an ISERDESE2 asking for dynamic clock inversion gets none.

I wrote that fix, then could not confirm it: the probe design fails to route here with `Failed to route arc 0 ... INBUF_EN_OUT to ILOGIC_X1Y115/DINV_OUT`, which is unrelated to the emission change. So I removed it rather than ship something I have not run end to end.

That is the same standard I have been applying all week and it has earned its keep — of three database-derived candidates I tested against the actual tool over the last two days, two behaved the opposite of how the sources read. The two ISERDES enables look right and are probably a two-line follow-up for whoever can route that case; I would rather flag them here than assert them.