### PR TITLE
xdc: match a one-bit vector port written Vivado-style as name[0] (fixes #46)

### DIFF
--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -86,6 +86,18 @@ void Arch::parseXdc(std::istream &in)
         }), s.end());
         return s;
     };
+    // Vivado calls a one-bit vector port "a[0]", but the JSON frontend collapses a
+    // width-1, offset-0 vector to the bare name "a" (get_bit_name(),
+    // frontend/frontend_base.h:367) because yosys' JSON carries nothing that tells
+    // `wire [0:0] a` apart from `wire a`. An XDC written against Vivado names
+    // therefore misses such a port, the constraint is dropped, and the design dies
+    // later with "port a of type PAD has no IOSTANDARD property" -- a message that
+    // points nowhere near the cause.  Strip a trailing "[0]" so the lookup can retry.
+    auto debus_zero = [](const std::string &str) {
+        if (str.size() > 3 && str.compare(str.size() - 3, 3, "[0]") == 0)
+            return str.substr(0, str.size() - 3);
+        return std::string();
+    };
     auto get_cells = [&](std::string str) {
         std::vector<CellInfo *> tgt_cells;
         if (str.empty() || str.front() != '[')
@@ -100,6 +112,11 @@ void Arch::parseXdc(std::istream &in)
         if (split.size() < 2)
             log_error("failed to parse target (on line %d)\n", lineno);
         IdString cellname = id(strip_quotes(split_name));
+        if (!cells.count(cellname)) {
+            std::string base = debus_zero(strip_quotes(split_name));
+            if (!base.empty() && cells.count(id(base)))
+                cellname = id(base);
+        }
         if (cells.count(cellname))
             tgt_cells.push_back(cells.at(cellname).get());
         else
@@ -123,6 +140,11 @@ void Arch::parseXdc(std::istream &in)
             log_error("failed to parse target (on line %d)\n", lineno);
         IdString netname = id(strip_quotes(split_name));
         NetInfo *maybe_net = getNetByAlias(netname);
+        if (maybe_net == nullptr) {
+            std::string base = debus_zero(strip_quotes(split_name));
+            if (!base.empty())
+                maybe_net = getNetByAlias(id(base));
+        }
         if (maybe_net != nullptr)
             tgt_nets.push_back(maybe_net);
         else


### PR DESCRIPTION
A port declared `wire [0:0] a` is called **`a[0]`** by Vivado, so that is what an XDC written against Vivado says. openXC7 could not match it, and the resulting error pointed nowhere near the cause.

## What happens

The JSON frontend collapses a width-1, offset-0 vector to the bare name `a` — `get_bit_name()`, `frontend/frontend_base.h:367`. It has to: yosys' JSON carries nothing that distinguishes `wire [0:0] a` from `wire a`. Both come out as `ports.a = {bits:[2]}`, no `upto`, no `offset`.

`get_cells`/`get_nets` in `xdc.cc` then do an exact `IdString` lookup of `a[0]`, miss, and drop the constraint. The build does not fail there — it fails later with

```
ERROR: port a of type PAD has no IOSTANDARD property
```

which is the sort of message you can stare at for a while. The `IOSTANDARD` was in the XDC; it just never landed.

## The fix

Both lookups retry with a trailing `[0]` stripped.

Deliberately at the lookup rather than in the frontend: renaming the port would change every consumer of the netlist for the sake of one notation, and the ambiguity is genuinely unresolvable from the JSON — there is no information in it to recover the declared width from.

## Verified

`xc7a200tfbg484-2`, `module top(input wire [0:0] a, output wire [0:0] y); assign y = ~a;`

| | result |
|---|---|
| before | exit 255, four `no cell named 'a[0]'` warnings, no bitstream |
| after | exit 0, and the FASM is **byte-identical** to the same design constrained with the bare `[get_ports {a}]` form |

That last line is the point — the fix makes the two spellings produce the same bitstream rather than merely making the error go away.

All five existing regression cases still pass.

## Related, not in this patch

`get_ports` still has no wildcard support at all, so a Vivado-style `[get_ports {din[*]}]` matches nothing. It warns rather than failing silently, so it is less nasty than this one, but it is the same family: XDC written for Vivado that openXC7 quietly declines. Worth its own issue if nobody has filed one.