### PR TITLE
xilinx: range-check CLKFBOUT_MULT_F instead of crashing (#78)

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2665,10 +2665,14 @@ struct FasmBackend
             0b1111111111001111101011111010010000000001UL
         };
         auto clkfbout_mult = (int)float_or_default(ci, "CLKFBOUT_MULT_F", 5.000);
-        if (63 < clkfbout_mult)
-            log_error("MMCME2_ADV: CLKFBOUT_MULT_F must not be greater than 63");
-        if (0 == clkfbout_mult)
-            log_error("MMCME2_ADV: CLKFBOUT_MULT_F must not be 0");
+        // lk_table[] and filter_lookup*[] hold 64 entries and are read at [mult-1].
+        // The old pair of tests rejected 0 and >63 but let every NEGATIVE value
+        // through, and (int) of an out-of-range double is undefined behaviour that
+        // differs by host -- x86-64 yields INT_MIN, arm64 saturates to INT_MAX -- so
+        // the same netlist crashed on one machine and passed on another (#78).
+        // Range-check both ends and name the offending value.
+        if (clkfbout_mult < 1 || clkfbout_mult > 64)
+            log_error("MMCME2_ADV: CLKFBOUT_MULT_F must be in the range 1..64 (got %d)\n", clkfbout_mult);
         write_int_vector("LKTABLE[39:0]", lk_table[clkfbout_mult - 1], 40);
 
         uint16_t filter_lookup_low [] = {


### PR DESCRIPTION
The MMCM path reads `lk_table[clkfbout_mult - 1]` and `filter_lookup*[clkfbout_mult - 1]` — 64-entry arrays — after testing only:

```cpp
if (63 < clkfbout_mult) log_error(...);
if (0 == clkfbout_mult) log_error(...);
```

Every **negative** value passes both tests and indexes out of bounds. That is the bus error in #78.

## It was host-dependent, which is why it looks unreproducible

`clkfbout_mult` comes from `(int)float_or_default(...)`, and `(int)` of an out-of-range double is undefined behaviour. Compiled both ways here on the same input:

```
arm64  : int64=4616977747989548237  double=4.61698e+18  (int)= 2147483647
x86_64 : int64=4616977747989548237  double=4.61698e+18  (int)=-2147483648
```

So the reporter's netlist **crashes on x86-64 and passes the `>63` guard on arm64**. Same input, same binary source, opposite outcomes — exactly the shape that gets a report closed as not-reproducible.

The PLL path already had this right (`if (pll_mult < 1) pll_mult = 1;` in `write_pll`), so `write_mmcm` was the only unguarded site.

## Verified

`xc7a200tfbg484-2`:

| | result |
|---|---|
| before | exit **139** (SIGSEGV), no diagnostic |
| after | exit 255, `MMCME2_ADV: CLKFBOUT_MULT_F must be in the range 1..64 (got -2000000000)` |
| control | a normal MMCM design still exits 0 |

Existing regression cases pass.

## This is deliberately not all of #78

It turns an undiagnosable crash into an error that names the offending value. It does **not** make the reporter's design build.

The value is garbage in the first place because yosys+ghdl hands VHDL reals over as a raw 64-bit IEEE-754 bit pattern rather than a decimal string, and `float_or_default()` reads that with `as_int64()` — hence ~4.6e18.

Decoding that properly needs a real ghdl-produced netlist to test against, and I do not have one: yosys turns Verilog reals into strings, so I could only reproduce the *shape* by hand-patching the JSON. I would rather ship the guard, which is fully verified, than guess at a heuristic for telling a 64-bit float pattern from a large integer.

**If the reporter can attach the `.json` that yosys+ghdl produced**, the decode is a short follow-up and #78 closes properly. Until then this at least means a clear error instead of a crash, on any host.