### PR TITLE
xc7: realize relocated CARRY4 pass-through lanes

### DIFF
--- a/xilinx/pack_carry_xc7.cc
+++ b/xilinx/pack_carry_xc7.cc
@@ -1168,8 +1168,17 @@ void XC7Packer::relocate_carry_o_fabric()
     // link.  Both cells pass the carry through their empty lanes with
     // S=VCC: in the MUXCY, CO = S ? CIN : DI, so S must be HIGH to
     // propagate (the earlier S=GND fill selected DI and silently zeroed
-    // the carry -- O, not CO, is what passes CIN when S is low).  Moved
-    // LUT/FF constraints are re-anchored onto the new CARRY4 (rows
+    // the carry -- O, not CO, is what passes CIN when S is low).
+    //
+    // A CARRY4 S pin is physically driven by the corresponding 6LUT O6;
+    // there is no direct constant input.  Atomic carry packing normally
+    // inserts and constrains a feed-through LUT for a constant S, but this
+    // split happens afterwards.  Do the same for every synthetic
+    // pass-through lane here.  Connecting $PACKER_VCC_NET directly to S
+    // routes in nextpnr's graph but emits no LUT INIT, leaving the hardware
+    // carry stage without the required high propagate value.
+    //
+    // Moved LUT/FF constraints are re-anchored onto the new CARRY4 (rows
     // assigned by the chain renumber).
     auto split_at = [&](CellInfo *c4, int i, CellInfo *root) -> CellInfo * {
         std::unique_ptr<CellInfo> nb{new CellInfo};
@@ -1211,14 +1220,36 @@ void XC7Packer::relocate_carry_o_fabric()
         connect_port(ctx, link.get(), nb.get(), ctx->id("CIN"));
         IdString lname = link->name;
         ctx->nets[lname] = std::move(link);
-        // pass-through fills: c4's freed head i..3 carries CO[i-1] up to its
-        // CO3; nb's empty tail 0..i-1 carries its CIN up to bit i
+        // Pass-through fills: c4's freed head i..3 carries CO[i-1] up to its
+        // CO3; nb's empty tail 0..i-1 carries its CIN up to bit i.  Realise
+        // each S=1 with a local 6LUT, just like pack_carries_atomic() does
+        // for constant S inputs before relocation.
         for (int b = i; b < 4; b++) {
             connect_port(ctx, vcc, c4, pname("S", b));
+            PortRef pr{c4, pname("S", b)};
+            auto s_feed = feed_through_lut(vcc, {pr});
+            CellInfo *s_lut = s_feed.get();
+            root->constr_children.push_back(s_lut);
+            s_lut->constr_parent = root;
+            s_lut->constr_x = 0;
+            s_lut->constr_y = 0;
+            s_lut->constr_abs_z = true;
+            s_lut->constr_z = (b << 4) | BEL_6LUT;
+            new_cells.push_back(std::move(s_feed));
             connect_port(ctx, gnd, c4, pname("DI", b));
         }
         for (int b = 0; b < i; b++) {
             connect_port(ctx, vcc, nb.get(), pname("S", b));
+            PortRef pr{nb.get(), pname("S", b)};
+            auto s_feed = feed_through_lut(vcc, {pr});
+            CellInfo *s_lut = s_feed.get();
+            root->constr_children.push_back(s_lut);
+            s_lut->constr_parent = root;
+            s_lut->constr_x = 0;
+            s_lut->constr_y = 0;
+            s_lut->constr_abs_z = true;
+            s_lut->constr_z = (b << 4) | BEL_6LUT;
+            new_cells.push_back(std::move(s_feed));
             connect_port(ctx, gnd, nb.get(), pname("DI", b));
         }
         // re-anchor the moved LUT/FF constraints onto the new CARRY4


### PR DESCRIPTION
## Problem

The XC7 atomic carry-O relocation can produce a routed, timing-clean bitstream that is non-functional on silicon when a CARRY4 lane has both `O` and non-chain `CO` fabric consumers.

On the archived reproducer, the merged #146 code places and routes successfully and reports two carry-O relocations, but the board does not respond to the first UART `WFF` command.

## Root cause

`relocate_carry_o_fabric()` runs after normal atomic carry operand packing. To split a CARRY4 while preserving the dedicated `CO3 -> CIN` cascade, it fills the unused lanes as carry pass-through stages with `S=1` and `DI=0`.

The relocation previously connected `$PACKER_VCC_NET` directly to those new `S` ports. That is valid in the logical routing graph, but it is not a physical XC7 realization: each CARRY4 `S` input is driven by the corresponding 6LUT `O6`, with no direct constant input. Because the lanes are created after `pack_carries_atomic()`, they missed the local feed-through LUTs that normal constant-`S` operands receive. The emitted FASM therefore lacked the required LUT INITs, and the synthetic stages did not reliably propagate carry on hardware.

The archived routed-netlist comparison makes the omission explicit:

- failing image: all eight synthetic pass-through `S` inputs are driven directly by `$PACKER_VCC_DRV`
- fixed image: each input is driven by its own local `[A-D]6LUT.O6`, with `INIT=2` for the one-input constant-high feed-through

## Change

- Create a local VCC feed-through LUT for every pass-through lane introduced by a carry split.
- Constrain each LUT to the matching 6LUT position and the same carry-chain row.
- Keep the atomic carry topology and the carry-O relocation itself.
- Remove the previous topology-local chain softening workaround; no CARRY4 is lowered to LUT logic.

## Validation

Tested on top of merged #146 (`05aaa06bce455ae6ed01efa1616ba7d3a9421ca7`):

- device: `xc7a200tfbg676-1`
- JSON SHA-256: `b80493fb220d4b10c0cd99a97bb0fe82693ed5cb7506b35c8694a30cce85cf63`
- seed: `1618238222`
- programmer: `openFPGALoader`, `jtag-smt2-nc`, 6 MHz, SRAM

| Configuration | Carry handling | P&R/timing | Hardware |
| --- | --- | --- | --- |
| merged #146 | 56 original atomic CARRY4s + 2 synthetic splits | passes | fails: no response to `WFF` |
| this PR | same 56 original atomic CARRY4s + 2 synthetic splits; 8 local pass-through LUTs | passes; `raw_clk` 126.01 MHz, `cpu_clk` 291.38 MHz | passes 3/3: `OK W=FF`, `OK R`, complete valid status response |

Additional checks:

- CMake build succeeds.
- `git diff --check` passes.
- Router2 converges with zero overused wires.
- Final FASM SHA-256: `81f185ab401c2e0dddaece9ef186e8d1e48028060fec7319b092d3e21eb56b16`.
- Final bitstream SHA-256: `f8a9d3478cd080f69e5799282d47d8d16fb7d8a117ae4353544cd73ce1f7e2e2`.

The archived reproducer is a diagnostic top, not the full SoC. Its synthesized `virtual_flag` input is constant zero, so `SRC=P` and changing diagnostic counters are expected. The pass criterion is successful `WFF`, `R`, and parsing of the complete status response.

## Relationship to #146

#146 fixes placement validity for impossible in-slice carry egress/FF arrangements. This PR fixes the separate configuration realization omitted by the late atomic carry split. The changes are complementary.
