### PR TITLE
ci(demos): build with Python, which a gated demo requires

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -86,9 +86,15 @@ jobs:
           # eigen); the default devshell is the toolchain env (yosys,
           # prjxray, ...) and has no cmake -- the runner's system cmake
           # would configure and fail the Boost lookup.
+          #
+          # BUILD_PYTHON must stay ON: ddr3-test-arty-s7 passes
+          # `--pre-place constraints.py --pre-route show_bels.py`, and those
+          # options only exist inside #ifndef NO_PYTHON (common/command.cc:114-123).
+          # With Python off the demo dies on `unrecognised option '--pre-place'`
+          # before it reaches anything this gate is meant to test.
           nix develop ./toolchain-nix#ci-tests.x86_64-linux --command bash -euxo pipefail -c '
             cmake -S nextpnr-xilinx -B build-pr \
-              -DARCH=xilinx -DBUILD_GUI=OFF -DBUILD_PYTHON=OFF \
+              -DARCH=xilinx -DBUILD_GUI=OFF -DBUILD_PYTHON=ON \
               -DUSE_OPENMP=ON -DCMAKE_BUILD_TYPE=Release \
               -DCURRENT_GIT_VERSION=0.9.2
             cmake --build build-pr --parallel 4


### PR DESCRIPTION
**The spartan7 leg has been failing on every PR** since #125 merged, including mine. It is not any of those PRs — the gate cannot pass as configured.

## What happens

`ddr3-test-arty-s7` sets:

```make
PNR_ARGS = --pre-place constraints.py --pre-route show_bels.py
```

Those options are registered only inside `#ifndef NO_PYTHON` (`common/command.cc:114-123`). The workflow builds with `-DBUILD_PYTHON=OFF`, so:

```
nextpnr-xilinx --chipdb ... --xdc arty_ddr3.xdc --json arty_ddr3.json --fasm arty_ddr3.fasm --pre-place ...
unrecognised option '--pre-place'
make: *** [../openXC7.mk:56: arty_ddr3.fasm] Error 255
```

It dies before reaching anything the gate exists to check.

## Why it appeared now — this one is on me

It was invisible until #125. Before that the gate ran the **devshell's pinned** `nextpnr-xilinx` rather than the one built from the PR, and the pinned build has Python enabled. #125 made the gate actually use the PR's binary — which is the point of that change — and that immediately exposed a build-flag mismatch that had been latent.

So the gate is now telling the truth and the truth is that this configuration never worked. Sorry for the noise in the interim; it is also why #131 and #132 are showing red on a leg that has nothing to do with them.

## Confirmed both ways

| build | `--pre-place` |
|---|---|
| Python **ON** (local) | accepted, proceeds to chipdb loading |
| Python **OFF** (CI) | `unrecognised option '--pre-place'` |

## The assumption to check in review

I cannot test the nix side from this machine: **does the `ci-tests` devshell provide boost-python?** If it does, this is the whole fix. If it does not, the configure step will fail and the alternative is to drop `ddr3-test-arty-s7` from the spartan7 subset instead — that project genuinely cannot build without the Python hooks, so the choice is between giving the gate Python or giving up that project's coverage.

I would rather have Python than lose a DDR3 demo from the matrix, but you know the devshell better than I do.