### PR TITLE
xilinx: don't abort on a BEL attribute naming an unknown tile

### DIFF
--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -147,7 +147,14 @@ BelId Arch::getBelByName(IdString name) const
                 break;
             }
         }
-    } else {
+    } else if (tile_by_name.count(split.first)) {
+        // Guarded to match the site_by_name branch above. An unrecognised name --
+        // a typo in a BEL attribute, most often -- used to reach .at() and throw
+        // an uncaught std::out_of_range, aborting with a libc++ message and no
+        // hint as to which cell was at fault. Returning an empty BelId instead
+        // lets the caller's own diagnostic run: placer_heap.cc:386 already says
+        // "No Bel named '<name>' located for this chip (processing BEL attribute
+        // on '<cell>')", which is the message the user needs.
         int tile = tile_by_name.at(split.first);
         auto &tile_info = chip_info->tile_types[chip_info->tile_insts[tile].type];
         IdString belname = id(split.second);


### PR DESCRIPTION
`getBelByName()` guards the `site_by_name` lookup with `.count()` but not the `tile_by_name` one, so a name matching neither reaches `.at()` and throws an uncaught `std::out_of_range`.

A typo in a `BEL` attribute therefore ends the run with:

```
libc++abi: terminating due to uncaught exception of type std::out_of_range: unordered_map::at: key not found
```

and a SIGABRT. No cell name, no BEL name, nothing to act on.

## The good message already exists

`placer_heap.cc:386` says exactly what is needed:

```
ERROR: No Bel named 'SLICE_X9Y999/AFF' located for this chip
       (processing BEL attribute on '$auto$ff.cc:337:slice$1512')
```

It could just never run, because the exception escaped first. Returning an empty `BelId` lets it.

## Verified

`xc7a200tfbg484-2`, an `FDRE` carrying `BEL = "SLICE_X9Y999/AFF"`:

| | result |
|---|---|
| before | exit **134**, uncaught `std::out_of_range`, no diagnostic |
| after | exit 255, the message above |

All five regression cases still pass.

## Why now

Found while testing #98. That issue was already fixed — `BEL` attributes on non-IO cells work now — which is precisely what makes a *typo* in one something users will start hitting. The crash was harmless while the feature was unusable.