### PR TITLE
xilinx: an IDELAYCTRL with no I/ODELAYs is a warning, not an error (fixes #60)

### DIFF
--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -1117,8 +1117,18 @@ void XC7Packer::pack_idelayctrl()
                 ioctrl_sites.insert(get_ioctrl_site(ci->attrs.at(ctx->id("X_IO_BEL")).as_string()));
             }
         }
-        if (ioctrl_sites.empty())
-            log_error("Found IDELAYCTRL but no I/ODELAYs in group %s\n", group_name.c_str());
+        if (ioctrl_sites.empty()) {
+            // An IDELAYCTRL whose group contains no I/ODELAYs is useless but legal --
+            // Vivado places it and drives RDY rather than rejecting the design, and a
+            // design can legitimately arrive here after optimisation removed the last
+            // delay element. Warn instead of failing the build. (fixes #60)
+            //
+            // The continue is load-bearing, not tidiness: falling through leaves
+            // dup_rdys empty and the RDY-AND tree below calls dup_rdys.front() on it.
+            log_warning("Found IDELAYCTRL '%s' but no I/ODELAYs in group %s; leaving it unreplicated\n",
+                        ctx->nameOf(idelayctrl), group_name.empty() ? "default" : group_name.c_str());
+            continue;
+        }
         NetInfo *rdy = get_net_or_empty(idelayctrl, ctx->id("RDY"));
         disconnect_port(ctx, idelayctrl, ctx->id("RDY"));
         std::vector<NetInfo *> dup_rdys;


### PR DESCRIPTION
`pack_idelayctrl()` rejected the design outright:

```
ERROR: Found IDELAYCTRL but no I/ODELAYs in group default
```

An `IDELAYCTRL` whose group holds no I/ODELAYs is useless, but it is **legal** — Vivado places it and drives `RDY` rather than failing — and a design can reach that state honestly, e.g. after optimisation removed the last delay element.

## The `continue` matters

It is not tidiness. Falling through with an empty `ioctrl_sites` leaves `dup_rdys` empty, and the RDY-AND tree at `pack_io_xc7.cc:1149` calls `dup_rdys.front()` on it whenever `RDY` is connected. So the old `log_error` was also standing in front of undefined behaviour.

## Verified, both directions

`xc7a200tfbg484-2`:

| design | before | after |
|---|---|---|
| `IDELAYCTRL` alone | exit 255 | exit 0, 138-line FASM, IDELAYCTRL placed, one clear warning |
| `IDELAYE2` + `IDELAYCTRL` in one `IODELAY_GROUP` | exit 0 | exit 0, 227-line FASM, 24 IDELAY lines, **no** warning |

The second row is the one that matters for review — the normal path is untouched, not merely "probably fine".

All five regression cases pass.

## The reporter's hypothesis was wrong, for the record

#60 suggests `IODELAY_GROUP` was being mishandled. It is not: group matching works today, because 3374e5a6 (2025-03-10, a month *after* the report) fixed a broken `as_int64` comparison on the group attribute. I checked a correctly grouped pair, an ungrouped pair, and a mismatched pair — only the genuinely empty group was fatal.

Worth saying because the obvious fix suggested by the issue text would have been the wrong one.