### PR TITLE
xilinx: run the final timing analysis after router2

### DIFF
--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -2149,6 +2149,15 @@ bool Arch::route()
     // exited 255; as a post-router fill it only consumes leftover resources.
     routeVcc();
     fixupRouting();
+    // router1 runs its own final timing analysis; the router2 flow
+    // historically ended without one, so the last "Max frequency" lines the
+    // user saw were the placer's pre-route ESTIMATES (printed mid-flow by
+    // placer1's refinement pass) presented as the result.  Analyse the
+    // actually-routed design: real net delays, per-clock Fmax, and the
+    // critical path breakdown.
+    if (router == "router2")
+        timing_analysis(getCtx(), true /* slack_histogram */, true /* print_fmax */, true /* print_path */,
+                        false /* warn_on_failure */);
     getCtx()->settings[getCtx()->id("route")] = 1;
     archInfoToAttributes();
     return result;


### PR DESCRIPTION
The router2 flow ended without a timing analysis: router1 runs its own (router1.cc, print_path enabled) but the router2 branch of Arch::route returned straight after routeVcc/fixupRouting.  The only "Max frequency" lines in a router2 log came from placer1's refinement pass - pre-route estimates printed mid-flow, easily mistaken for the final result (they sit hundreds of lines before the router even starts, and understate the routed design when the router recovers slack or overstate it when routing detours).

Run the real analysis on the routed design at the end of the router2 branch: actual net delays, per-clock Fmax against the --freq target, the slack histogram, and the critical path breakdown (print_path) that QoR work needs.