### PR TITLE
xdc: only report not-in-design constraint targets in verbose mode

### DIFF
--- a/xilinx/xdc.cc
+++ b/xilinx/xdc.cc
@@ -29,6 +29,7 @@ void Arch::parseXdc(std::istream &in)
     std::string line;
     std::string linebuf;
     int lineno = 0;
+    int missing_targets = 0;
 
     auto isempty = [](const std::string &str) {
         return std::all_of(str.begin(), str.end(), [](char c) { return std::isspace(c); });
@@ -102,9 +103,16 @@ void Arch::parseXdc(std::istream &in)
         IdString cellname = id(strip_quotes(split_name));
         if (cells.count(cellname))
             tgt_cells.push_back(cells.at(cellname).get());
-        else
-            log_warning("%s: no cell named '%s' (on line %d) - this target is ignored\n",
-                        split.front().c_str(), cellname.c_str(this), lineno);
+        else {
+            // A board-level XDC legitimately constrains every pin of the
+            // board while a design uses a subset (the standard apio/PCF
+            // practice), so these are not reportable events: stay silent
+            // like the ice40 flow does, and itemise only in verbose mode.
+            missing_targets++;
+            if (getCtx()->verbose)
+                log_info("%s: no cell named '%s' (on line %d) - this target is ignored\n", split.front().c_str(),
+                         cellname.c_str(this), lineno);
+        }
         return tgt_cells;
     };
 
@@ -125,9 +133,12 @@ void Arch::parseXdc(std::istream &in)
         NetInfo *maybe_net = getNetByAlias(netname);
         if (maybe_net != nullptr)
             tgt_nets.push_back(maybe_net);
-        else
-            log_warning("%s: no net or port named '%s' (on line %d) - this target is ignored\n",
-                        split.front().c_str(), netname.c_str(this), lineno);
+        else {
+            missing_targets++;
+            if (getCtx()->verbose)
+                log_info("%s: no net or port named '%s' (on line %d) - this target is ignored\n",
+                         split.front().c_str(), netname.c_str(this), lineno);
+        }
         return tgt_nets;
     };
 
@@ -267,6 +278,10 @@ void Arch::parseXdc(std::istream &in)
     }
     if (!isempty(linebuf))
         log_error("unexpected end of XDC file\n");
+    if (missing_targets > 0 && getCtx()->verbose)
+        log_info("%d XDC constraint target(s) reference ports or nets that are not in this design and were "
+                 "ignored (a board-level XDC normally constrains more pins than a design uses)\n",
+                 missing_targets);
 }
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
apio-style flows use one board-level XDC that constrains every pin of the board, while each design uses a subset - so nextpnr printed one 'no cell named X - this target is ignored' warning per unused board pin (47 of them for a blinky on a Basys3). This is the standard practice in the ecosystem (icestudio passes ice40 PCFs with every board pin and the flow stays silent), not a reportable event.

Stay silent about them by default; --verbose itemises each ignored target and prints a closing count.

Fixes the noise reported in FPGAwars/apio#920.