### PR TITLE
xilinx: RAM256X1S mux tree belongs in its own slice half, not the SPO half

### DIFF
--- a/xilinx/pack_dram.cc
+++ b/xilinx/pack_dram.cc
@@ -452,7 +452,7 @@ void XilinxPacker::pack_dram()
                     z--;
                 }
                 create_muxf_tree(base, "O", o_pre, addressw_high, o,
-                        m256 ? 4 : (ctx->xc7 ? 2 : 6));
+                        m256 ? 0 : (ctx->xc7 ? 2 : 6));
                 packed_cells.insert(ci->name);
             }
         } else if (cs.memtype == ctx->id("RAMS32")


### PR DESCRIPTION
Fixes the placer failure @hansfbaier reported on `litex-ddr-arty-s7-deephier`. **The design places and routes with this one-line change.**

```
ERROR: Unable to find legal placement for cell
       'l2_cache.tag_mem.0.9.genblk1.genblk1[0].genblk1.slice/ADDR0'
```

## Not a capacity problem

`xc7s50` has **2400 SLICEM** against the **44** `RAM256X1S` groups the design needs — a 54× margin. Thousands of free sites, not one legal. Same shape as @cavearr's qmtech finding.

## The offset is borrowed from a two-memory layout

`constrain_muxf_tree` computes `curr_z = zoffset * 16`, and cells are addressed `(half << 6) | (i << 4)`. So **offset 4 lands at z=64 — the other half of the tile.**

That is exactly right for a dual-port `RAM256X1D`, which holds *two* memories:

```
:405  RAM*X1D, SPO ->  m256 ? 4 : (ctx->xc7 ? 2 : 6)      one half
:422  RAM*X1D, DPO ->  m256 ? 0 : (ctx->xc7 ? 0 : 4)      the other
:454  RAM*X1S,  O  ->  m256 ? 4 : (ctx->xc7 ? 2 : 6)      <-- copied
```

The single-port path copied the SPO arm, and its own comment admits it: *"Mirror of the SPO half of the RAM128X1D / RAM256X1D path."*

But a `RAM256X1S` is **one** memory, not the upper half of two. Its four `/ADDR<i>` cells occupy `z = height-1 .. 0` (`height` is 4 on xc7), and the mux tree was then constrained into the *second* half — stretching a single-port memory across two slices, so no site could ever satisfy the cluster.

Only the `m256` arm changes. `RAM128X1S` keeps `ctx->xc7 ? 2 : 6`.

## Verified

`xc7s50csga324-1`, the design that could not place:

| | result |
|---|---|
| before | `ERROR: Unable to find legal placement ... /ADDR0` |
| after | exit 0, placed and routed, **194815-line FASM** |

`RAM128X1S` unchanged (266-line FASM, identical to before), and all five `demo-projects` regression cases pass.

I built a spartan7 chipdb to reproduce this, so the failing design is on my bench rather than inferred.

## What this does not claim

That the SoC boots. This gets the design through place-and-route; whether it runs is a separate question, and on `litex-ddr-arty-s7-deephier` nobody has had a bitstream to try yet. @hansfbaier, this is the one that needs a board.

Worth noting the two are independent: #129 is about the PLL never leaving reset on the *old* litex design; this is about the *new* one not placing at all. Both are needed.

Analysis trail on #141, including a wrong turn I corrected — I first localised this to the dual-port branch, which it is not.