### PR TITLE
xilinx: wire RAM128X1S scalar A0..A6 into the DRAM control set

### DIFF
--- a/xilinx/pack_dram.cc
+++ b/xilinx/pack_dram.cc
@@ -243,9 +243,17 @@ void XilinxPacker::pack_dram()
             continue;
         auto &dt = dt_iter->second;
         DRAMControlSet dcs;
-        for (int i = 0; i < dt.abits; i++)
-            dcs.wa.push_back(get_net_or_empty(
-                    ci, ctx->id(dt.abits <= 6 ? ("A" + std::to_string(i)) : ("A[" + std::to_string(i) + "]"))));
+        for (int i = 0; i < dt.abits; i++) {
+            // Address pin style is per-primitive, not per-width: RAM128X1S has
+            // 7 abits but SCALAR pins A0..A6 (unlike RAM128X1D/RAM256X1S,
+            // which use an A[] bus), so the width-based guess left every
+            // address (and with it WADR/WA7USED) unconnected. Try the scalar
+            // name first and fall back to the bus form.
+            NetInfo *an = get_net_or_empty(ci, ctx->id("A" + std::to_string(i)));
+            if (an == nullptr)
+                an = get_net_or_empty(ci, ctx->id("A[" + std::to_string(i) + "]"));
+            dcs.wa.push_back(an);
+        }
         dcs.wclk = get_net_or_empty(ci, ctx->id("WCLK"));
         dcs.we = get_net_or_empty(ci, ctx->id("WE"));
         dcs.wclk_inv = bool_or_default(ci->params, ctx->id("IS_WCLK_INVERTED"));


### PR DESCRIPTION
The DRAM control-set collector guessed the address pin style from the width: <=6 bits scalar (A0..), more bus (A[i]). RAM128X1S breaks the guess - it has 7 address bits but SCALAR pins A0..A6 (unlike RAM128X1D/RAM256X1S, which use a bus) - so every address lookup missed: cs.wa ended up all-null, WADR/RADR were never connected, and the packed RAM placed and routed cleanly while reading from floating addresses and never seeing WA7USED or a write strobe. Reported by gHashTag as 'upstream emits zero write-address lines for a writable RAM'.

Try the scalar name first and fall back to the bus form, so every primitive style wires its write-address bus.

Verified against a Vivado golden of a RAM128X1S with a distinctive INIT: before the fix our SLICEM config lacked WA7USED and any WEMUX setting; after it both appear (WA7USED + WEMUX.CE, as in the golden) with the INIT content bit-identical at the same LUT positions.