### PR TITLE
Propagate placer1_refine failure out of placer_heap

### DIFF
--- a/common/placer_heap.cc
+++ b/common/placer_heap.cc
@@ -313,7 +313,12 @@ class HeAPPlacer
         placer1_cfg.hpwl_scale_x = cfg.hpwl_scale_x;
         placer1_cfg.hpwl_scale_y = cfg.hpwl_scale_y;
         placer1_cfg.netShareWeight = cfg.netShareWeight;
-        placer1_refine(ctx, placer1_cfg);
+        // placer1_refine() returns false when its final post-placement validity
+        // check fails; that check's log_error is caught inside placer1_refine, so
+        // discarding the result let a known-invalid placement reach the router,
+        // where it resurfaced as an unreadable intra-site arc failure.
+        if (!placer1_refine(ctx, placer1_cfg))
+            return false;
 
         return true;
     }


### PR DESCRIPTION
Found while running the seed sweep @cavearr asked for on #142. Not the carry hazard itself — the reason that hazard is so hard to read.

## The defect

`common/placer_heap.cc` called

```cpp
placer1_refine(ctx, placer1_cfg);

return true;
```

`placer1_refine` ends with the post-placement validity check. That check's `log_error` is **caught inside `placer1_refine`** (`common/placer1.cc:1419`) and converted into a `false` return. Discarding it means a placement the placer has already declared invalid goes on to the router.

`Arch::place()` gets this right for the `sa` path (`xilinx/arch.cc:901` checks the result); only the default heap path drops it.

## What that costs the user

Same run, `litex-ddr-arty-s7-deephier`, `xc7s50csga324-1`, seed 3:

```
ERROR: post-placement validity check failed for Bel 'SLICE_X28Y80/A5FF'
       (cell '$auto$ff.cc:337:slice$33048')
Info: Running post-placement legalisation...
Info: Routing global clocks...
ERROR: Failed to route arc 0 of net '...replace_alu$26238.Y[21]',
       from SITEWIRE/SLICE_X28Y80/CARRY4_O1 to SITEWIRE/SLICE_X28Y80/AFFMUX_OUT.
```

The second error is the one the user acts on, and it points at the router. The real diagnosis is in the first line, eight seconds and several stages earlier. This is very close to what Hans hit — an intra-site arc failure that names neither the invalid bel nor the placement as the cause.

After the change seed 3 stops at the first error, exit 255, nothing runs after it.

## Regression check

Four seeds on the same design:

| seed | before | after |
|---|---|---|
| 1 | exit 0 | exit 0 |
| 2 | exit 0 | — |
| 3 | route error after the ignored check | **stops at the check** |
| 4 | exit 0 | exit 0 |

The passing seeds trip the validity check **zero** times, so on this evidence making it fatal costs no design that builds today.

**The honest limit on that claim:** n=4, one design, one part. The check firing has been a perfect predictor of eventual failure here, but I have not shown it cannot fire spuriously somewhere else. If a design exists that trips the check and still routes, this turns it from passing to failing — that is the risk to weigh, and `--force` remains the escape hatch (`ctx->force` already downgrades the same check to a warning at `placer1.cc:502`).

Worth pointing at the demos gate before merging; I would rather that ran than take my four seeds as sufficient.