### PR TITLE
xilinx: fix use-after-free when a LUT6_2 feeds a MUXF7/8/9 tree

### DIFF
--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -209,19 +209,21 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         return pairs;
 
     for (CellInfo *ci : to_split) {
-        // A BEL pin on the LUT6_2 itself names a single physical resource for
-        // what is about to become two independent cells; there's no defined
-        // rule here for which half (if either) should inherit it, and
-        // silently dropping it would place a "constrained" instance wherever
-        // the placer likes. Fail loudly rather than guess.
-        if (ci->attrs.count(id_BEL))
-            log_error("LUT6_2 cell '%s' has a BEL constraint; splitting a pre-placed LUT6_2 is not supported\n",
-                       ci->name.c_str(ctx));
-
         NetInfo *o5 = get_net_or_empty(ci, ctx->id("O5"));
         NetInfo *o6 = get_net_or_empty(ci, ctx->id("O6"));
         NetInfo *i5 = get_net_or_empty(ci, ctx->id("I5"));
         Property init = get_or_default(ci->params, ctx->id("INIT"), Property()).extract(0, 64);
+
+        // A BEL pin on the LUT6_2 itself names a single physical resource for
+        // what is about to become two independent cells. That's fine as long
+        // as only one output is actually used -- the lone surviving half just
+        // inherits it below -- but if both O5 and O6 are driven there's no
+        // defined rule for which half should get it. Fail loudly rather than
+        // guess in that case.
+        if (ci->attrs.count(id_BEL) && o5 != nullptr && o6 != nullptr)
+            log_error("LUT6_2 cell '%s' has a BEL constraint but drives both O5 and O6; splitting it in two "
+                       "would leave that constraint ambiguous\n",
+                       ci->name.c_str(ctx));
 
         // Build one LUT<n_in> cell driving `out`, whose INIT is the
         // 2^n_in-bit slice of the LUT6_2 INIT starting at bit `lo`.
@@ -247,6 +249,11 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             // instance -- unlike a BEL pin, a region is just a bbox and
             // applies equally well to both halves.
             half->region = ci->region;
+            // The BEL-ambiguity check above guarantees at most one half is
+            // ever actually built when the original cell was BEL-constrained,
+            // so it's safe to hand that BEL straight to whichever one it is.
+            if (ci->attrs.count(id_BEL))
+                half->attrs[id_BEL] = ci->attrs.at(id_BEL);
             new_cells.push_back(std::move(half));
         };
 

--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -220,7 +220,8 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         // inherits it below -- but if both O5 and O6 are driven there's no
         // defined rule for which half should get it. Fail loudly rather than
         // guess in that case.
-        if (ci->attrs.count(id_BEL) && o5 != nullptr && o6 != nullptr)
+        bool bel_constrained_with_both_outputs_used = ci->attrs.count(id_BEL) && o5 != nullptr && o6 != nullptr;
+        if (bel_constrained_with_both_outputs_used)
             log_error("LUT6_2 cell '%s' has a BEL constraint but drives both O5 and O6; splitting it in two "
                        "would leave that constraint ambiguous\n",
                        ci->name.c_str(ctx));
@@ -231,7 +232,8 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             if (out == nullptr)
                 return;
             IdString half_name = ctx->id(ci->name.str(ctx) + suffix);
-            if (ctx->cells.count(half_name))
+            bool half_name_collides = ctx->cells.count(half_name);
+            if (half_name_collides)
                 log_error("splitting LUT6_2 cell '%s' would create cell '%s', which already exists\n",
                            ci->name.c_str(ctx), half_name.c_str(ctx));
             std::unique_ptr<CellInfo> half = create_cell(ctx, ctx->id("LUT" + std::to_string(n_in)), half_name);
@@ -252,7 +254,8 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             // The BEL-ambiguity check above guarantees at most one half is
             // ever actually built when the original cell was BEL-constrained,
             // so it's safe to hand that BEL straight to whichever one it is.
-            if (ci->attrs.count(id_BEL))
+            bool bel_constrained = ci->attrs.count(id_BEL);
+            if (bel_constrained)
                 half->attrs[id_BEL] = ci->attrs.at(id_BEL);
             new_cells.push_back(std::move(half));
         };
@@ -319,8 +322,11 @@ void XilinxPacker::constrain_lut6_2_pairs(const std::vector<std::pair<IdString, 
         // pair unpaired rather than corrupt an existing constraint -- it
         // costs the extra LUT bel split_lut6_2() already accepts for the
         // non-constant-I5 case.
-        if (lut6->constr_parent != nullptr || lut6->constr_abs_z || !lut6->constr_children.empty() ||
-            lut5->constr_parent != nullptr || lut5->constr_abs_z || !lut5->constr_children.empty())
+        bool lut6_already_constrained =
+                lut6->constr_parent != nullptr || lut6->constr_abs_z || !lut6->constr_children.empty();
+        bool lut5_already_constrained =
+                lut5->constr_parent != nullptr || lut5->constr_abs_z || !lut5->constr_children.empty();
+        if (lut6_already_constrained || lut5_already_constrained)
             continue;
 
         rename_port(ctx, lut5, id_O6, id_O5);

--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -36,6 +36,16 @@ NEXTPNR_NAMESPACE_BEGIN
 void XilinxPacker::flush_cells()
 {
     for (auto pcell : packed_cells) {
+        CellInfo *dying = ctx->cells[pcell].get();
+        // A cell being deleted here must not still be referenced by another
+        // cell's cluster/constraint pointers: constrain_muxf_tree() (and any
+        // similar pass) records constr_parent/constr_children by raw
+        // CellInfo*, not by name, so a pass that deletes a cell it has
+        // already constrained (or that some other cell constrains) leaves a
+        // dangling pointer the placer later dereferences -- silently, far
+        // from here, and without a helpful stack trace. Trip loudly instead.
+        NPNR_ASSERT(dying->constr_parent == nullptr);
+        NPNR_ASSERT(dying->constr_children.empty());
         for (auto &port : ctx->cells[pcell]->ports) {
             disconnect_port(ctx, ctx->cells[pcell].get(), port.first);
         }
@@ -199,6 +209,15 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         return pairs;
 
     for (CellInfo *ci : to_split) {
+        // A BEL pin on the LUT6_2 itself names a single physical resource for
+        // what is about to become two independent cells; there's no defined
+        // rule here for which half (if either) should inherit it, and
+        // silently dropping it would place a "constrained" instance wherever
+        // the placer likes. Fail loudly rather than guess.
+        if (ci->attrs.count(id_BEL))
+            log_error("LUT6_2 cell '%s' has a BEL constraint; splitting a pre-placed LUT6_2 is not supported\n",
+                       ci->name.c_str(ctx));
+
         NetInfo *o5 = get_net_or_empty(ci, ctx->id("O5"));
         NetInfo *o6 = get_net_or_empty(ci, ctx->id("O6"));
         NetInfo *i5 = get_net_or_empty(ci, ctx->id("I5"));
@@ -209,8 +228,11 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         auto make_half = [&](const char *suffix, NetInfo *out, int n_in, int lo) {
             if (out == nullptr)
                 return;
-            std::unique_ptr<CellInfo> half = create_cell(
-                    ctx, ctx->id("LUT" + std::to_string(n_in)), ctx->id(ci->name.str(ctx) + suffix));
+            IdString half_name = ctx->id(ci->name.str(ctx) + suffix);
+            if (ctx->cells.count(half_name))
+                log_error("splitting LUT6_2 cell '%s' would create cell '%s', which already exists\n",
+                           ci->name.c_str(ctx), half_name.c_str(ctx));
+            std::unique_ptr<CellInfo> half = create_cell(ctx, ctx->id("LUT" + std::to_string(n_in)), half_name);
             for (int i = 0; i < n_in; i++) {
                 IdString p = ctx->id("I" + std::to_string(i));
                 half->addInput(p);
@@ -221,6 +243,10 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             half->addOutput(ctx->id("O"));
             connect_port(ctx, out, half.get(), ctx->id("O"));
             half->params[ctx->id("INIT")] = init.extract(lo, 1 << n_in);
+            // Preserve any region (area) constraint carried by the original
+            // instance -- unlike a BEL pin, a region is just a bbox and
+            // applies equally well to both halves.
+            half->region = ci->region;
             new_cells.push_back(std::move(half));
         };
 
@@ -279,6 +305,16 @@ void XilinxPacker::constrain_lut6_2_pairs(const std::vector<std::pair<IdString, 
         CellInfo *lut5 = ctx->cells.at(p.second).get();
         if (lut6->type != id_SLICE_LUTX || lut5->type != id_SLICE_LUTX)
             continue;
+        // Either half may already carry a constraint from an earlier pass
+        // (e.g. constrain_muxf_tree(), if that half feeds a MUXF7/8/9 input).
+        // Overwriting constr_parent here would desync it from the other
+        // cell's constr_children list it's still sitting in, so leave such a
+        // pair unpaired rather than corrupt an existing constraint -- it
+        // costs the extra LUT bel split_lut6_2() already accepts for the
+        // non-constant-I5 case.
+        if (lut6->constr_parent != nullptr || lut6->constr_abs_z || !lut6->constr_children.empty() ||
+            lut5->constr_parent != nullptr || lut5->constr_abs_z || !lut5->constr_children.empty())
+            continue;
 
         rename_port(ctx, lut5, id_O6, id_O5);
         lut5->attrs.erase(ctx->id("X_ORIG_PORT_O6"));
@@ -295,11 +331,9 @@ void XilinxPacker::constrain_lut6_2_pairs(const std::vector<std::pair<IdString, 
     }
 }
 
-void XilinxPacker::pack_luts()
+void XilinxPacker::pack_luts(const std::vector<std::pair<IdString, IdString>> &lut6_2_pairs)
 {
     log_info("Packing LUTs..\n");
-
-    auto lut6_2_pairs = split_lut6_2();
 
     std::unordered_map<IdString, XFormRule> lut_rules;
     for (int k = 1; k <= 6; k++) {
@@ -1358,11 +1392,20 @@ bool Arch::pack()
         packer.pack_plls();
         packer.pack_gt();
         packer.pack_gbs();
+        // Must run before pack_muxfs()/pack_carries()/pack_srls(): those
+        // passes walk driver.cell across nets with no cell-type check
+        // (e.g. constrain_muxf_tree() following a MUXF7 input back through
+        // whatever feeds it), so a LUT6_2 downstream of any of them can be
+        // constrained into a cluster and then have split_lut6_2() delete it
+        // out from under that cluster, leaving a dangling CellInfo* the
+        // placer later dereferences. Splitting first removes LUT6_2 as a
+        // type before any of those passes ever run.
+        auto lut6_2_pairs = packer.split_lut6_2();
         packer.pack_muxfs();
         packer.pack_carries();
         packer.relocate_carry_o_fabric();
         packer.pack_srls();
-        packer.pack_luts();
+        packer.pack_luts(lut6_2_pairs);
         packer.pack_dram();
         packer.pack_bram();
         packer.pack_dsps();
@@ -1381,9 +1424,12 @@ bool Arch::pack()
         packer.pack_iologic();
         packer.pack_idelayctrl();
         packer.pack_clocking();
+        // See the matching comment in the xc7 branch above: must run before
+        // pack_muxfs()/pack_carries().
+        auto lut6_2_pairs = packer.split_lut6_2();
         packer.pack_muxfs();
         packer.pack_carries();
-        packer.pack_luts();
+        packer.pack_luts(lut6_2_pairs);
         packer.pack_dram();
         packer.pack_bram();
         packer.pack_uram();

--- a/xilinx/pack.h
+++ b/xilinx/pack.h
@@ -119,7 +119,7 @@ struct XilinxPacker
     void pack_inverters();
     std::vector<std::pair<IdString, IdString>> split_lut6_2();
     void constrain_lut6_2_pairs(const std::vector<std::pair<IdString, IdString>> &pairs);
-    void pack_luts();
+    void pack_luts(const std::vector<std::pair<IdString, IdString>> &lut6_2_pairs);
     void pack_ffs();
     void pack_lutffs();
 


### PR DESCRIPTION
## Summary

- Fixes a use-after-free segfault when a `LUT6_2` feeds a `MUXF7`/`MUXF8`/`MUXF9` input. `pack_muxfs()`'s `constrain_muxf_tree()` walks `driver.cell` across nets with no type check and can set `constr_parent`/`constr_children` on a `LUT6_2` before `split_lut6_2()` (previously run inside `pack_luts()`, after `pack_muxfs()`) deletes that exact cell — leaving other cells holding a dangling `CellInfo*` that the HEAP placer later dereferences.
- Fix moves `split_lut6_2()` to run before `pack_muxfs()`/`pack_carries()`/`pack_srls()` in both the xc7 and Ultrascale flows, so `LUT6_2` no longer exists as a type by the time any untyped driver-walk pass runs — this closes the bug class at its root rather than adding a type check to one call site.
- `flush_cells()` now asserts a cell being deleted has no live `constr_parent`/`constr_children`, so any future instance of this class fails loudly at the deletion site instead of segfaulting later, deep in the placer.
- `constrain_lut6_2_pairs()` no longer overwrites `constr_parent` on a half already constrained by an earlier pass (e.g. its own mux-tree constraint) — found via adversarial testing on top of the reorder: a `LUT6_2` that is both constant-I5 pairable *and* drives a `MUXF7` input hit the same dangling/desynced-constraint problem through a different path. Such a pair is now left unpaired (costs one extra LUT bel — the same tradeoff already accepted for the non-constant-I5 case) instead of corrupting constraint state.
- `split_lut6_2()` now propagates the original cell's `region` constraint to both halves (previously silently dropped).
- `split_lut6_2()` fails loudly (`log_error`) instead of silently misbehaving in two cases: a split-half name colliding with an existing cell (previously a bare `NPNR_ASSERT` deep inside `flush_cells()`), and a BEL-constrained `LUT6_2` that drives *both* O5 and O6 (genuinely ambiguous — no rule for which half should keep the BEL). A BEL-constrained `LUT6_2` using only one output now correctly inherits the BEL onto that single half, matching pre-split behaviour (this was a regression caught by an independent review pass — see below).

## Scope

`xilinx/pack.cc` + `xilinx/pack.h` only. Two commits:
1. `6d4e5df1` — the use-after-free fix (reorder, guards, region propagation, `flush_cells` assert).
2. `0d9fda6a` — follow-up fix for a regression an independent Opus review caught in commit 1: the BEL-constraint guard was over-broad and rejected a previously-working case (BEL-pinned `LUT6_2` using only O6).

## Testing

Verified against hand-built repro netlists (chipdb: xc7z010clg400), each hitting a distinct code path:
- Original UAF: `LUT6_2.O6 -> MUXF7`. Segfaults before this fix; places and routes cleanly after.
- Constant-I5 `LUT6_2` with no mux involvement: confirms the pair still re-fuses onto one physical LUT (not two).
- Paired `LUT6_2` (constant I5) with O6 also feeding a `MUXF7`: exercises the reordered flow's interaction with mux constraining.
- Same, but with O5 (not O6) feeding the `MUXF7`: the actual conflicting case for `constrain_lut6_2_pairs()`'s new guard — confirmed load-bearing by temporarily removing the guard and observing a different placer assertion fire (`common/placer_heap.cc:1068`).
- Split-half name collision (`<name>$LUT5` pre-existing): confirms the new `log_error` fires with a clear message instead of the old bare assert.
- BEL-constrained `LUT6_2` driving only O6: previously hard-errored (regression introduced by commit 1's original, over-broad BEL guard); now packs/places/routes cleanly.
- BEL-constrained `LUT6_2` driving both O5 and O6: confirms this still correctly errors (genuinely ambiguous case).

All cases place and route cleanly except the two intentional `log_error` cases, which fail with the expected, specific message.

## Out of scope (documented, not fixed here)

- A non-constant-I5 `LUT6_2` still costs 2 LUT bels instead of 1 — the placer's fracturable-LUT legality check (`arch_place.cc`) refuses a 5LUT companion whenever the 6LUT genuinely uses all 6 inputs. Closing this needs an arch-level change, not a packer-level one, and doesn't affect correctness — a pre-existing, accepted limitation.
- A constant-I5-pairable `LUT6_2` whose O6 half single-fanout-drives a `CARRY4` input can have that half adopted directly into the carry chain by `pack_carries()` before `constrain_lut6_2_pairs()` gets a chance to re-fuse the pair, permanently costing 2 LUT bels instead of 1. Not a correctness bug (no crash, no wrong output), just a LUT-utilization nit in a narrow corner case — deliberately left out of this PR.
- A pre-existing, unrelated bug in `constrain_muxf_tree()`: its own reentrancy guard (`curr->type == id_SLICE_LUTX && ...`) can never fire for a plain LUT, because `SLICE_LUTX` cells don't exist yet at `pack_muxfs()` time. A LUT with fanout into two different mux trees can therefore still get double-constrained. This is unchanged by, and unrelated to, `LUT6_2` — flagged by review for future work, not part of this PR.

## Review

An independent Opus-model review pass was run against commit 1 specifically. It found the BEL-guard regression above (fixed in commit 2) and confirmed the reordering itself is sound: no pass between `split_lut6_2()` and `pack_luts()` deletes a LUT5/LUT6 half, and `constrain_lut6_2_pairs()`'s guard is symmetric and can't leave a half half-fixed.
