### PR TITLE
Bring main up to stable-backports (carries #148)

### DIFF
--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -209,19 +209,21 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         return pairs;
 
     for (CellInfo *ci : to_split) {
-        // A BEL pin on the LUT6_2 itself names a single physical resource for
-        // what is about to become two independent cells; there's no defined
-        // rule here for which half (if either) should inherit it, and
-        // silently dropping it would place a "constrained" instance wherever
-        // the placer likes. Fail loudly rather than guess.
-        if (ci->attrs.count(id_BEL))
-            log_error("LUT6_2 cell '%s' has a BEL constraint; splitting a pre-placed LUT6_2 is not supported\n",
-                       ci->name.c_str(ctx));
-
         NetInfo *o5 = get_net_or_empty(ci, ctx->id("O5"));
         NetInfo *o6 = get_net_or_empty(ci, ctx->id("O6"));
         NetInfo *i5 = get_net_or_empty(ci, ctx->id("I5"));
         Property init = get_or_default(ci->params, ctx->id("INIT"), Property()).extract(0, 64);
+
+        // A BEL pin on the LUT6_2 itself names a single physical resource for
+        // what is about to become two independent cells. That's fine as long
+        // as only one output is actually used -- the lone surviving half just
+        // inherits it below -- but if both O5 and O6 are driven there's no
+        // defined rule for which half should get it. Fail loudly rather than
+        // guess in that case.
+        if (ci->attrs.count(id_BEL) && o5 != nullptr && o6 != nullptr)
+            log_error("LUT6_2 cell '%s' has a BEL constraint but drives both O5 and O6; splitting it in two "
+                       "would leave that constraint ambiguous\n",
+                       ci->name.c_str(ctx));
 
         // Build one LUT<n_in> cell driving `out`, whose INIT is the
         // 2^n_in-bit slice of the LUT6_2 INIT starting at bit `lo`.
@@ -247,6 +249,11 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             // instance -- unlike a BEL pin, a region is just a bbox and
             // applies equally well to both halves.
             half->region = ci->region;
+            // The BEL-ambiguity check above guarantees at most one half is
+            // ever actually built when the original cell was BEL-constrained,
+            // so it's safe to hand that BEL straight to whichever one it is.
+            if (ci->attrs.count(id_BEL))
+                half->attrs[id_BEL] = ci->attrs.at(id_BEL);
             new_cells.push_back(std::move(half));
         };
 

--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -220,7 +220,8 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         // inherits it below -- but if both O5 and O6 are driven there's no
         // defined rule for which half should get it. Fail loudly rather than
         // guess in that case.
-        if (ci->attrs.count(id_BEL) && o5 != nullptr && o6 != nullptr)
+        bool bel_constrained_with_both_outputs_used = ci->attrs.count(id_BEL) && o5 != nullptr && o6 != nullptr;
+        if (bel_constrained_with_both_outputs_used)
             log_error("LUT6_2 cell '%s' has a BEL constraint but drives both O5 and O6; splitting it in two "
                        "would leave that constraint ambiguous\n",
                        ci->name.c_str(ctx));
@@ -231,7 +232,8 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             if (out == nullptr)
                 return;
             IdString half_name = ctx->id(ci->name.str(ctx) + suffix);
-            if (ctx->cells.count(half_name))
+            bool half_name_collides = ctx->cells.count(half_name);
+            if (half_name_collides)
                 log_error("splitting LUT6_2 cell '%s' would create cell '%s', which already exists\n",
                            ci->name.c_str(ctx), half_name.c_str(ctx));
             std::unique_ptr<CellInfo> half = create_cell(ctx, ctx->id("LUT" + std::to_string(n_in)), half_name);
@@ -252,7 +254,8 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             // The BEL-ambiguity check above guarantees at most one half is
             // ever actually built when the original cell was BEL-constrained,
             // so it's safe to hand that BEL straight to whichever one it is.
-            if (ci->attrs.count(id_BEL))
+            bool bel_constrained = ci->attrs.count(id_BEL);
+            if (bel_constrained)
                 half->attrs[id_BEL] = ci->attrs.at(id_BEL);
             new_cells.push_back(std::move(half));
         };
@@ -319,8 +322,11 @@ void XilinxPacker::constrain_lut6_2_pairs(const std::vector<std::pair<IdString, 
         // pair unpaired rather than corrupt an existing constraint -- it
         // costs the extra LUT bel split_lut6_2() already accepts for the
         // non-constant-I5 case.
-        if (lut6->constr_parent != nullptr || lut6->constr_abs_z || !lut6->constr_children.empty() ||
-            lut5->constr_parent != nullptr || lut5->constr_abs_z || !lut5->constr_children.empty())
+        bool lut6_already_constrained =
+                lut6->constr_parent != nullptr || lut6->constr_abs_z || !lut6->constr_children.empty();
+        bool lut5_already_constrained =
+                lut5->constr_parent != nullptr || lut5->constr_abs_z || !lut5->constr_children.empty();
+        if (lut6_already_constrained || lut5_already_constrained)
             continue;
 
         rename_port(ctx, lut5, id_O6, id_O5);

--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -36,6 +36,16 @@ NEXTPNR_NAMESPACE_BEGIN
 void XilinxPacker::flush_cells()
 {
     for (auto pcell : packed_cells) {
+        CellInfo *dying = ctx->cells[pcell].get();
+        // A cell being deleted here must not still be referenced by another
+        // cell's cluster/constraint pointers: constrain_muxf_tree() (and any
+        // similar pass) records constr_parent/constr_children by raw
+        // CellInfo*, not by name, so a pass that deletes a cell it has
+        // already constrained (or that some other cell constrains) leaves a
+        // dangling pointer the placer later dereferences -- silently, far
+        // from here, and without a helpful stack trace. Trip loudly instead.
+        NPNR_ASSERT(dying->constr_parent == nullptr);
+        NPNR_ASSERT(dying->constr_children.empty());
         for (auto &port : ctx->cells[pcell]->ports) {
             disconnect_port(ctx, ctx->cells[pcell].get(), port.first);
         }
@@ -199,6 +209,15 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         return pairs;
 
     for (CellInfo *ci : to_split) {
+        // A BEL pin on the LUT6_2 itself names a single physical resource for
+        // what is about to become two independent cells; there's no defined
+        // rule here for which half (if either) should inherit it, and
+        // silently dropping it would place a "constrained" instance wherever
+        // the placer likes. Fail loudly rather than guess.
+        if (ci->attrs.count(id_BEL))
+            log_error("LUT6_2 cell '%s' has a BEL constraint; splitting a pre-placed LUT6_2 is not supported\n",
+                       ci->name.c_str(ctx));
+
         NetInfo *o5 = get_net_or_empty(ci, ctx->id("O5"));
         NetInfo *o6 = get_net_or_empty(ci, ctx->id("O6"));
         NetInfo *i5 = get_net_or_empty(ci, ctx->id("I5"));
@@ -209,8 +228,11 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
         auto make_half = [&](const char *suffix, NetInfo *out, int n_in, int lo) {
             if (out == nullptr)
                 return;
-            std::unique_ptr<CellInfo> half = create_cell(
-                    ctx, ctx->id("LUT" + std::to_string(n_in)), ctx->id(ci->name.str(ctx) + suffix));
+            IdString half_name = ctx->id(ci->name.str(ctx) + suffix);
+            if (ctx->cells.count(half_name))
+                log_error("splitting LUT6_2 cell '%s' would create cell '%s', which already exists\n",
+                           ci->name.c_str(ctx), half_name.c_str(ctx));
+            std::unique_ptr<CellInfo> half = create_cell(ctx, ctx->id("LUT" + std::to_string(n_in)), half_name);
             for (int i = 0; i < n_in; i++) {
                 IdString p = ctx->id("I" + std::to_string(i));
                 half->addInput(p);
@@ -221,6 +243,10 @@ std::vector<std::pair<IdString, IdString>> XilinxPacker::split_lut6_2()
             half->addOutput(ctx->id("O"));
             connect_port(ctx, out, half.get(), ctx->id("O"));
             half->params[ctx->id("INIT")] = init.extract(lo, 1 << n_in);
+            // Preserve any region (area) constraint carried by the original
+            // instance -- unlike a BEL pin, a region is just a bbox and
+            // applies equally well to both halves.
+            half->region = ci->region;
             new_cells.push_back(std::move(half));
         };
 
@@ -279,6 +305,16 @@ void XilinxPacker::constrain_lut6_2_pairs(const std::vector<std::pair<IdString, 
         CellInfo *lut5 = ctx->cells.at(p.second).get();
         if (lut6->type != id_SLICE_LUTX || lut5->type != id_SLICE_LUTX)
             continue;
+        // Either half may already carry a constraint from an earlier pass
+        // (e.g. constrain_muxf_tree(), if that half feeds a MUXF7/8/9 input).
+        // Overwriting constr_parent here would desync it from the other
+        // cell's constr_children list it's still sitting in, so leave such a
+        // pair unpaired rather than corrupt an existing constraint -- it
+        // costs the extra LUT bel split_lut6_2() already accepts for the
+        // non-constant-I5 case.
+        if (lut6->constr_parent != nullptr || lut6->constr_abs_z || !lut6->constr_children.empty() ||
+            lut5->constr_parent != nullptr || lut5->constr_abs_z || !lut5->constr_children.empty())
+            continue;
 
         rename_port(ctx, lut5, id_O6, id_O5);
         lut5->attrs.erase(ctx->id("X_ORIG_PORT_O6"));
@@ -295,11 +331,9 @@ void XilinxPacker::constrain_lut6_2_pairs(const std::vector<std::pair<IdString, 
     }
 }
 
-void XilinxPacker::pack_luts()
+void XilinxPacker::pack_luts(const std::vector<std::pair<IdString, IdString>> &lut6_2_pairs)
 {
     log_info("Packing LUTs..\n");
-
-    auto lut6_2_pairs = split_lut6_2();
 
     std::unordered_map<IdString, XFormRule> lut_rules;
     for (int k = 1; k <= 6; k++) {
@@ -1358,11 +1392,20 @@ bool Arch::pack()
         packer.pack_plls();
         packer.pack_gt();
         packer.pack_gbs();
+        // Must run before pack_muxfs()/pack_carries()/pack_srls(): those
+        // passes walk driver.cell across nets with no cell-type check
+        // (e.g. constrain_muxf_tree() following a MUXF7 input back through
+        // whatever feeds it), so a LUT6_2 downstream of any of them can be
+        // constrained into a cluster and then have split_lut6_2() delete it
+        // out from under that cluster, leaving a dangling CellInfo* the
+        // placer later dereferences. Splitting first removes LUT6_2 as a
+        // type before any of those passes ever run.
+        auto lut6_2_pairs = packer.split_lut6_2();
         packer.pack_muxfs();
         packer.pack_carries();
         packer.relocate_carry_o_fabric();
         packer.pack_srls();
-        packer.pack_luts();
+        packer.pack_luts(lut6_2_pairs);
         packer.pack_dram();
         packer.pack_bram();
         packer.pack_dsps();
@@ -1381,9 +1424,12 @@ bool Arch::pack()
         packer.pack_iologic();
         packer.pack_idelayctrl();
         packer.pack_clocking();
+        // See the matching comment in the xc7 branch above: must run before
+        // pack_muxfs()/pack_carries().
+        auto lut6_2_pairs = packer.split_lut6_2();
         packer.pack_muxfs();
         packer.pack_carries();
-        packer.pack_luts();
+        packer.pack_luts(lut6_2_pairs);
         packer.pack_dram();
         packer.pack_bram();
         packer.pack_uram();

--- a/xilinx/pack.h
+++ b/xilinx/pack.h
@@ -119,7 +119,7 @@ struct XilinxPacker
     void pack_inverters();
     std::vector<std::pair<IdString, IdString>> split_lut6_2();
     void constrain_lut6_2_pairs(const std::vector<std::pair<IdString, IdString>> &pairs);
-    void pack_luts();
+    void pack_luts(const std::vector<std::pair<IdString, IdString>> &lut6_2_pairs);
     void pack_ffs();
     void pack_lutffs();
 


### PR DESCRIPTION
`main` became the default branch but sits 4 commits behind `stable-backports`, so **the fix from #148 is currently absent from the default branch** — a fresh clone does not have it.

`main` is a strict ancestor of `stable-backports` (`git merge-base --is-ancestor` passes, compare API reports `ahead_by=0 behind_by=4`), so this is a **fast-forward**. No cherry-picks, no rewritten authorship — the same four objects:

```
4dd779f5  Hans Baier  Merge pull request #148 from jasonzeng124/fix/lut6-2-muxf-uaf
7d649e0b  Jason Zeng  xilinx: extract self-documenting bools for LUT6_2 split conditions
bfdeaf7c  Jason Zeng  xilinx: only reject BEL-constrained LUT6_2 when both outputs are used
31c8ea77  Jason Zeng  xilinx: fix use-after-free when a LUT6_2 feeds a MUXF7/8/9 tree
```

Credit is @jasonzeng124's and @hansfbaier's; this PR only moves the branch pointer.

## How it arose, so it does not recur

`main` was cut at 00:37 on 2026-08-18; #148 merged into `stable-backports` at 02:14, because that PR still targeted the old branch. There are now **no open PRs targeting `stable-backports`** — the last two were mine (#151, #120) and I have retargeted them to `main`. So this is a one-off gap, not an ongoing leak.

## Verified before proposing

Built at `4dd779f5` and ran `litex-ddr-arty-s7` (deephier branch of demo-projects) on `xc7s50csga324-1`:

| seed | result |
|---|---|
| 1 | exit 0 — 193271-line FASM |
| 3 | exit 0 — 194024 |
| 8 | exit 0 — 192243 |

Seeds 3 and 8 are the two that failed the carry site-exit class before #146, so this also confirms #146 and #148 coexist. FASM differs from the pre-#148 output, which is expected: #148 changes when a `LUT6_2` may be packed, so the netlist legitimately changes.

**What I did not verify:** the repo's own `regression/` suite — it lives on demo-projects' default branch and my working copy is on the deephier branch. I did not want to claim a gate I had not actually run.

@hansfbaier — you said you are focusing on review and merge, so this is meant to be a one-click item. If you would rather fast-forward `main` directly, or delete it and rename `stable-backports` instead, close this; the branch topology is your call and I did not want to guess.
