### PR TITLE
fasm: record the run identity in a header

### DIFF
--- a/common/command.cc
+++ b/common/command.cc
@@ -167,8 +167,13 @@ po::options_description CommandHandler::getGeneralOptions()
 
 void CommandHandler::setupContext(Context *ctx)
 {
-    if (ctx->settings.find(ctx->id("seed")) != ctx->settings.end())
+    if (ctx->settings.find(ctx->id("seed")) != ctx->settings.end()) {
         ctx->rngstate = ctx->setting<uint64_t>("seed");
+        // settings["seed"] is overwritten with the derived rngstate at the
+        // end of this function, so record the restored value while it is
+        // still the seed and not the state.
+        ctx->settings[ctx->id("seed.arg")] = ctx->rngstate;
+    }
 
     if (vm.count("verbose")) {
         ctx->verbose = true;
@@ -185,6 +190,7 @@ void CommandHandler::setupContext(Context *ctx)
 
     if (vm.count("seed")) {
         ctx->rngseed(vm["seed"].as<int>());
+        ctx->settings[ctx->id("seed.arg")] = vm["seed"].as<int>();
     }
 
     if (vm.count("randomize-seed")) {
@@ -194,6 +200,7 @@ void CommandHandler::setupContext(Context *ctx)
             r = rand();
         } while (r == 0);
         ctx->rngseed(r);
+        ctx->settings[ctx->id("seed.arg")] = r;
     }
 
     if (vm.count("slack_redist_iter")) {

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -24,6 +24,7 @@
 #include <fstream>
 #include "log.h"
 #include "nextpnr.h"
+#include "version.h"
 #include "pins.h"
 #include "util.h"
 
@@ -5198,6 +5199,22 @@ void Arch::writeFasm(const std::string &filename)
     std::ofstream out(filename);
     if (!out)
         log_error("failed to open file %s for writing (%s)\n", filename.c_str(), strerror(errno));
+
+    // Run identity.  A seed alone does not identify a run: the same --seed on
+    // two different binaries or chipdbs gives two different placements, so
+    // "it fails at seed 4" is not reproducible information on its own.  This
+    // cost a real round of confusion between contributors comparing seed
+    // sweeps.  Comments are dropped by fasm2frames, so the bitstream and the
+    // demos gate's normalized-hash comparison are unaffected.
+    out << "# nextpnr-xilinx " << GIT_DESCRIBE_STR << std::endl;
+    out << "# chipdb " << chip_info->name.get() << " version " << chip_info->version
+        << " generator " << chip_info->generator.get() << std::endl;
+    if (settings.count(id("seed.arg")))
+        out << "# placer seed " << getCtx()->setting<uint64_t>("seed.arg") << std::endl;
+    else
+        out << "# placer seed default" << std::endl;
+    if (settings.count(id("seed")))
+        out << "# placer rngstate " << getCtx()->setting<uint64_t>("seed") << std::endl;
 
     FasmBackend be(getCtx(), out);
     be.write_fasm();


### PR DESCRIPTION
A seed alone does not identify a run. @cavearr and I both swept seeds on this design and got failures at **different indices** — his at 4, mine at 3 and 8 — from binaries that differed slightly. Same failure class, non-corresponding seed numbers. It took a round of confusion to work out that "seed 4" and "seed 4" were not the same experiment.

The artefact should say what produced it.

```
# nextpnr-xilinx 0.9.2-44-ga70ae4a8
# chipdb xc7s50csga324-1 version 1 generator prjxray
# placer seed 7
# placer rngstate 1748364256391707781
CLBLM_R_X41Y77.SLICEM_X0.ALUT.INIT[63:0] = 64'b0000...
```

## Why `seed.arg` is needed

`setupContext` ends with `settings["seed"] = ctx->rngstate`, so by the time anything downstream reads it, the value the user typed is gone — replaced by a derived state. My first attempt printed that state and it was neither `7` nor readable. So the seed is now recorded separately at the point it is known.

Three sites, all covered and each verified by running it:

| invocation | header line |
|---|---|
| `--seed 7` | `# placer seed 7` |
| `-r` | `# placer seed 1958354700` |
| neither | `# placer seed default` |

`rngstate` is printed alongside because it is what actually drives placement, and it is the thing that would differ if the derivation ever changed.

## Nothing downstream breaks

- **FASM comments** — checked against the `fasm` library: a three-line input with two `#` comments parses to three records, one carrying a feature. Comments are dropped before frames.
- **The demos gate** — `normhash` compares `.bit` files, not FASM, so a comment header cannot reach it.

## Blast radius, stated plainly

`common/command.cc` is shared by every architecture. The change there is additive — one new settings key, no behaviour change, no existing key touched — but it is not xilinx-local and a maintainer may reasonably want it scoped differently. The header emission itself is entirely in `xilinx/fasm.cc`.

I have not run the other architectures' tests.

@hansfbaier — small and self-contained, aimed at your review-only mode. If you would rather the `common/` half were done another way, say so and I will rework it rather than defend it.
