### PR TITLE
xc7: pack BUFIO onto the BUFIO_BUFIO bel

### DIFF
--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -125,6 +125,23 @@ void XC7Packer::prepare_clocking()
             save_orig_port("CE",  "CE");
             save_orig_port("CLR", "CLR");
             save_orig_port("O",   "O");
+        } else if (ci->type == ctx->id("BUFIO")) {
+            // BUFIO is the undivided I/O clock buffer and sits in its own
+            // site, one BEL of type BUFIO_BUFIO carrying just two pins --
+            // I and O.  No CE and no CLR, which is the difference from the
+            // BUFR case above; there is nothing to tie off.  Same
+            // rename-to-match-the-BEL treatment and the same identity port
+            // tags, for the json2dcp reason given there.
+            //
+            // Without this branch the cell reached the placer still typed
+            // BUFIO, no bel of that type exists to bind it to, and the run
+            // died with "no Bels remaining of type 'BUFIO'" while twenty
+            // sat unused -- the resource table counts bels by site type and
+            // so listed them as available the whole time.
+            save_orig_type();
+            ci->type = id_BUFIO_BUFIO;
+            save_orig_port("I", "I");
+            save_orig_port("O", "O");
         }
     }
 }


### PR DESCRIPTION
Closes half of #149. BUFIO appeared nowhere in the packer, so the cell reached the placer still typed `BUFIO`, no bel carries that type, and the run died:

```
ERROR: Unable to place cell 'bufio_inst', no Bels remaining of type 'BUFIO'
```

Twenty bels sat unused while it said that. The resource table counts by site type, so it printed `BUFIO: 0/20` — available — for the whole run, which is why the log reads like a placement pressure problem rather than a missing packer branch.

The fix is the treatment the `BUFR` branch directly above it already gets: rename the cell type to match the bel, and tag identity port mappings so json2dcp keeps the connections. BUFIO is the simpler of the two — two pins, `I` and `O`, no `CE` and no `CLR`, nothing to tie off.

## Verified

`xc7a35tcsg324-1`, clock-capable pad → IBUF → BUFIO → ODDR, the ODDR being what pulls the clock into the I/O column:

| | result |
|---|---|
| before | `ERROR: no Bels remaining of type 'BUFIO'` |
| after | exit 0, `BUFIO_BUFIO` placed, FASM emitted |

with the regional clock route in the output:

```
HCLK_IOI3_X113Y78.HCLK_IOI_IOCLK0.HCLK_IOI_BUFIO_O0
HCLK_IOI3_X113Y78.HCLK_IOI_IO_PLL_CLK0_DMUX.HCLK_IOI_I2IOCLK_TOP0
```

No regression on the BUFR side: both probes from #149 still pass, and the divide probe's FASM is **byte-identical** to its output before this patch.

## Not verified, and I would rather say so than have it assumed

**Whether the resulting bitstream actually enables the BUFIO on silicon.** prjxray-db defines `BUFR_Y{0,1,2}.IN_USE` and `BUFR_Y*.BUFR_DIVIDE`, and defines **no `BUFIO_Y*` feature at all**. So either BUFIO needs no enable bit and the routing pips above are the whole configuration, or the bit is missing from the database — which would be the "HCLK_L enables are never emitted" half of #149, still open. The FASM here carries routing and nothing else.

Placement and routing are fixed by this patch. Configuration is unproven in either direction, and the distinction matters: a design can now get all the way to a bitstream that is dead on the board, which is a worse failure than refusing to place. Settling it needs a Vivado reference bitstream for the same probe, or a scope on real hardware. My boards are XC7A200T, so the probe needs re-pinning before I can do the hardware half; I can do that if it is useful, but a Vivado diff from someone who has it would settle it faster.

The probe used here is [`bufio_top.v`](https://github.com/gHashTag/trinity-fpga/blob/main/research/bufr-probe/bufio_top.v), alongside the BUFR pair from #149.

For anyone rebuilding on macOS: `-DUSE_OPENMP=OFF` (Apple clang has no `-fopenmp`), `-DCMAKE_POLICY_VERSION_MINIMUM=3.5` for cmake 4.x, and `bbaexport.py` needs both the `prjxray-db` and `nextpnr-xilinx-meta` submodules — with only the first it dies on a missing `wire_intents.json` that reads like database corruption.
