### PR TITLE
Fix wrong LUT truth table in the bitstream when one net drives two pins of a LUT

### DIFF
--- a/xilinx/arch_place.cc
+++ b/xilinx/arch_place.cc
@@ -1754,7 +1754,11 @@ void Arch::fixupRouting()
                     auto &orig_attr = lut6->attrs[id("X_ORIG_PORT_" + p.str(this))].str;
                     bool first = true;
                     for (auto &nc : new_connections.at(p)) {
-                        orig_attr += orig_ports_l6[nc] + (first ? "" : " ");
+                        // The separator belongs BEFORE each element after the first.
+                        // Appending it after built "I1I3 " instead of "I1 I3" for a
+                        // shared pin, which every reader that splits on " " then
+                        // mis-parses -- see the note in xilinx/fasm.cc.
+                        orig_attr += (first ? "" : " ") + orig_ports_l6[nc];
                         first = false;
                     }
                     if (orig_attr.empty())
@@ -1770,7 +1774,11 @@ void Arch::fixupRouting()
                     auto &orig_attr = lut5->attrs[id("X_ORIG_PORT_" + p.str(this))].str;
                     bool first = true;
                     for (auto &nc : new_connections.at(p)) {
-                        orig_attr += orig_ports_l5[nc] + (first ? "" : " ");
+                        // The separator belongs BEFORE each element after the first.
+                        // Appending it after built "I1I3 " instead of "I1 I3" for a
+                        // shared pin, which every reader that splits on " " then
+                        // mis-parses -- see the note in xilinx/fasm.cc.
+                        orig_attr += (first ? "" : " ") + orig_ports_l5[nc];
                         first = false;
                     }
                     if (orig_attr.empty())

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -579,7 +579,23 @@ struct FasmBackend
                 if (!lut->attrs.count(ctx->id("X_ORIG_PORT_" + phys_inputs[j].str(ctx))))
                     continue;
                 std::string orig = lut->attrs.at(ctx->id("X_ORIG_PORT_" + phys_inputs[j].str(ctx))).as_string();
-                boost::split(phys_to_log[j], orig, boost::is_any_of(" "));
+                // Match the logical-input names rather than trusting the
+                // separator.  X_ORIG_PORT_A<n> lists every logical input that
+                // shares this physical pin, and fixupRouting() used to build
+                // that list with the separator on the wrong side, so a shared
+                // pin came out as "I1I3 " instead of "I1 I3".  Splitting on " "
+                // then yielded the token "I1I3", which is not the name of any
+                // logical input.
+                for (size_t p = 0; p < orig.size(); p++) {
+                    if (orig[p] != 'I')
+                        continue;
+                    size_t q = p + 1;
+                    while (q < orig.size() && orig[q] >= '0' && orig[q] <= '9')
+                        q++;
+                    if (q > p + 1)
+                        phys_to_log[j].push_back(orig.substr(p, q - p));
+                    p = q - 1;
+                }
             }
             int lbound = 0, ubound = 64;
             // Fracturable LUTs
@@ -593,8 +609,21 @@ struct FasmBackend
                 for (int k = 0; k < 6; k++) {
                     if ((j & (1 << k)) == 0)
                         continue;
-                    for (auto &p2l : phys_to_log[k])
-                        log_index |= (1 << log_to_bit[p2l]);
+                    for (auto &p2l : phys_to_log[k]) {
+                        // find(), never operator[]: operator[] inserts a
+                        // missing key with value 0, so an unparseable name was
+                        // silently encoded as if the pin drove I0 and the LUT
+                        // received a truth table that is not its function --
+                        // in the bitstream only.  The JSON and the SDF stayed
+                        // correct, so the design failed on the die and nowhere
+                        // else.
+                        auto lb = log_to_bit.find(p2l);
+                        if (lb == log_to_bit.end())
+                            log_error("LUT '%s': X_ORIG_PORT_%s names logical input '%s', "
+                                      "which this cell does not have\n",
+                                      ctx->nameOf(lut), phys_inputs[k].c_str(ctx), p2l.c_str());
+                        log_index |= (1 << lb->second);
+                    }
                 }
                 bits[j] = (init.str.at(log_index) == Property::S1);
             }


### PR DESCRIPTION
## LUTs with a shared input pin get the wrong truth table in the bitstream

`X_ORIG_PORT_A<n>` records which *logical* LUT inputs sit on each *physical* A-pin. When one net reaches several inputs of the same LUT, the router puts them all on one pin and the attribute holds a list.

`Arch::fixupRouting()` builds that list with the separator on the wrong side:

```cpp
orig_attr += orig_ports_l6[nc] + (first ? "" : " ");
```

so `{I1, I3}` is written as `"I1I3 "` instead of `"I1 I3"`. (The other list-builder, in the LUT-pair legaliser, prefixes the separator and is correct — hence only some cells are affected.)

Every reader splits this attribute on `" "`. On the run-together form that yields the token `"I1I3"`, which is not the name of any logical input. `FasmBackend` then did:

```cpp
log_index |= (1 << log_to_bit[p2l]);
```

`log_to_bit` is an `unordered_map`, and `operator[]` **inserts a missing key with value 0** — so the unparseable token was silently encoded as if the pin drove `I0`, and the LUT was written into the bitstream with a truth table that is not its function.

There is no error and no warning. The routed JSON, the SDF, and every simulation built from them stay correct. **Only the bitstream is wrong**, so the design fails on the die and nowhere else.

### Reproducer

`repro_orig_port.cc` (attached below) is standalone — no nextpnr build needed:

```
SHIPPED:  X_ORIG_PORT_A1 = "I1I3 "
            token "I1I3"   (NOT A LOGICAL INPUT) -> bit 0
            token ""       (NOT A LOGICAL INPUT) -> bit 0
            physical A1 asserts logical bits 0x01  (want 0x0a = I1|I3)

FIXED:    X_ORIG_PORT_A1 = "I1 I3"
            token "I1" -> bit 1
            token "I3" -> bit 3
            physical A1 asserts logical bits 0x0a  (want 0x0a = I1|I3)
```

On a real design, this finds it in the routed JSON — non-empty before, empty after:

```sh
grep -o 'X_ORIG_PORT_A[0-9]" *: *"[^"]*"' design_routed.json | grep -E 'I[0-9]+I[0-9]+'
```

### How often does this fire?

A shared pin is not an exotic condition — it happens whenever one net reaches two inputs of the same LUT, and sign-extended datapaths produce them in bulk. In a 32-bit design I build for xc7z010:

- **618 of 7290** LUTs had a shared physical pin (525 with two logical inputs, 93 with three)
- **118** of those attributes came out in the malformed spelling
- the resulting bitstream **failed 9 of 16** test vectors on hardware
- with this branch: **0** malformed attributes, **16 of 16** vectors pass

The failure mode on silicon was a hang, not a wrong answer — a comparator whose truth table had been permuted made a loop condition never terminate. It took a while to find precisely because every simulation of the design was correct.

### Contents

1. **`xilinx: put the X_ORIG_PORT separator before the name, not after`** — the actual fix, in `arch_place.cc`. One-character-position change, ×2 (lut6 and lut5).
2. **`xilinx: do not let an unknown X_ORIG_PORT name encode itself as I0`** — `fasm.cc` uses `find()` + `log_error()` instead of `operator[]`, and matches the `I<n>` names directly rather than trusting the delimiter, so an older or third-party JSON does not silently mis-encode either.

Commit 1 alone fixes the bitstream. Commit 2 is what turns a future mapping bug into a stopped flow instead of wrong hardware.

### Question for maintainers

Is `log_error` the right severity in commit 2? It will hard-fail on any JSON produced by an *older* nextpnr — which is arguably correct, since such a JSON would otherwise produce a wrong bitstream, but it is a behaviour change for existing artifacts. The alternative is `log_warning` plus skipping the pin. Happy to switch it.

### Testing

`xc7z010clg400` (EBAZ4205), openXC7 flow, yosys → nextpnr-xilinx → prjxray `fasm2frames` → `xc7frames2bit`. Verified on hardware: the design's self-check went from 7/16 to 16/16, and the FASM is unchanged between the pre-polish and final form of commit 2 (byte-identical output).
