### PR TITLE
xilinx: inferred DSP48E1 ignores its A operand -- INMODE/ALUMODE2/3/OPMODE6 never get their tile constant bits

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -5176,8 +5176,20 @@ void write_gtx_channel(CellInfo *ci)
 
         write_bit("ZADREG[0]", !bool_or_default(ci->params, ctx->id("ADREG"), true));
         write_bit("ZALUMODEREG[0]", !bool_or_default(ci->params, ctx->id("ALUMODEREG")));
-        write_bit("ZAREG_2_ACASCREG_1", !bool_or_default(ci->params, ctx->id("ACASCREG")));
-        write_bit("ZBREG_2_BCASCREG_1", !bool_or_default(ci->params, ctx->id("BCASCREG")));
+        // AREG_2_ACASCREG_1 is prjxray's name for a CONJUNCTION, not for
+        // ACASCREG: fuzzers/100-dsp-mskpat/generate.py sets it to
+        // (AREG == 2 && ACASCREG == 1).  Its Z-form bit therefore belongs in
+        // the bitstream whenever that conjunction is FALSE.  Deciding it from
+        // ACASCREG alone mis-encodes the case yosys emits whenever it absorbs
+        // one level of input register into the DSP -- AREG=1 with
+        // ACASCREG=1 -- which wrote no bit at all and reads back on silicon
+        // as AREG=2, one pipeline stage deeper than the netlist asked for.
+        // The multiply then samples its operands a cycle late and the design
+        // returns wrong products with a correct netlist.  Same for B.
+        auto acascreg = int_or_default(ci->params, ctx->id("ACASCREG"), 1);
+        auto bcascreg = int_or_default(ci->params, ctx->id("BCASCREG"), 1);
+        write_bit("ZAREG_2_ACASCREG_1", !(areg == 2 && acascreg == 1));
+        write_bit("ZBREG_2_BCASCREG_1", !(breg == 2 && bcascreg == 1));
         write_bit("ZCARRYINREG[0]", !bool_or_default(ci->params, ctx->id("CARRYINREG")));
         write_bit("ZCARRYINSELREG[0]", !bool_or_default(ci->params, ctx->id("CARRYINSELREG")));
         write_bit("ZCREG[0]", !bool_or_default(ci->params, ctx->id("CREG"), true));

--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -21,6 +21,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/range/adaptor/reversed.hpp>
+#include <cctype>
 #include <fstream>
 #include "log.h"
 #include "nextpnr.h"
@@ -5213,9 +5214,39 @@ void write_gtx_channel(CellInfo *ci)
             boost::split(pins, attr_value, boost::is_any_of(" "));
             for (auto pin : pins) {
                 if (boost::empty(pin)) continue;
+                // These pins have no interconnect path into the site, so the
+                // tile bit IS the pin: it bypasses the site's optional input
+                // inverter, and the ZIS_*_INVERTED bits fasm.cc writes apply
+                // only to the routed pins.  The bit therefore has to carry the
+                // LOGICAL value -- flip the constant when the netlist asked
+                // for an inversion.
+                //
+                // Splitting the trailing index off matters: erase_all() of
+                // "0123456789" turned "INMODE1" into "INMODE" and then looked
+                // up IS_INMODE_INVERTED, which yosys never emits (it writes
+                // the per-bit IS_INMODE[1]_INVERTED), so `inv` was always
+                // false and every bussed pin got the un-flipped constant.
+                // That is the "seems to be inverted for unknown reasons" that
+                // kept INMODE/ALUMODE2/ALUMODE3 commented out of the packer's
+                // const-pin list in pack_dsp_xc7.cc.
                 auto pin_basename = pin;
-                boost::erase_all(pin_basename, "0123456789");
-                auto inv = bool_or_default(ci->params, ctx->id("IS_" + pin_basename + "_INVERTED"), 0);
+                std::string idx;
+                while (!pin_basename.empty() && std::isdigit((unsigned char)pin_basename.back())) {
+                    idx.insert(idx.begin(), pin_basename.back());
+                    pin_basename.pop_back();
+                }
+                bool inv = bool_or_default(ci->params, ctx->id("IS_" + pin + "_INVERTED"), false);
+                if (!idx.empty()) {
+                    inv |= bool_or_default(
+                            ci->params,
+                            ctx->id("IS_" + pin_basename + "[" + idx + "]_INVERTED"), false);
+                    inv |= ((int_or_default(ci->params,
+                                            ctx->id("IS_" + pin_basename + "_INVERTED"), 0)
+                             >> std::stoi(idx)) & 0x1) != 0;
+                } else {
+                    inv |= bool_or_default(ci->params, ctx->id("IS_" + pin_basename + "_INVERTED"),
+                                           false);
+                }
                 auto net_name = inv ? (const_net_name == "GND" ? "VCC" : "GND") : const_net_name;
                 write_bit(dsp + "_" + pin + ".DSP_" + net_name + "_" + tile_side);
             }

--- a/xilinx/pack_dsp_xc7.cc
+++ b/xilinx/pack_dsp_xc7.cc
@@ -121,12 +121,33 @@ void XC7Packer::pack_dsps()
                 // prjxray has extra bits for these ports to hardwire them to VCC/GND
                 // as these seem to be internal to the tile,
                 // this saves us from having to route those externally
+                // The pins below have NO routing path into the site at all:
+                // they appear in prjxray's segbits_dsp_{l,r}.db only as
+                // <PIN>.DSP_GND_* / <PIN>.DSP_VCC_* and in no ppips/pips
+                // list, so a tile-local constant bit is the ONLY way to give
+                // them a value.  Leaving one out does not fail routing -- it
+                // silently emits no bit, the pin sits at the tile default 0,
+                // and the site's ZIS_*_INVERTED bit (written independently by
+                // fasm.cc's write_bus_zinv) flips it to 1.
+                //
+                // INMODE, ALUMODE2/3 and OPMODE6 were missing.  For a plain
+                // inferred multiplier that turns INMODE 00000 into 11111 --
+                // and INMODE[1]=1 gates the multiplier's A input to zero
+                // (UG479 Table 1-11) -- OPMODE[6:4] 000 into 100 (P feedback
+                // instead of zero) and ALUMODE[3:2] 00 into 11.  The DSP then
+                // ignores its A operand entirely and returns near-constant
+                // junk, with a correct netlist and clean timing.
+                //
+                // The earlier "these seem to be inverted for unknown reasons"
+                // is that ZIS_*_INVERTED: the pin must be driven with the
+                // UNINVERTED value (VCC for a wanted 0 when the site inverts),
+                // which is what connecting it to its actual constant net does.
                 if (boost::starts_with(n, "D") ||
                     boost::starts_with(n, "RSTD") ||
-                    // TODO: these seem to be inverted for unknown reasons
-                    // boost::starts_with(n, "INMODE") ||
-                    // boost::starts_with(n, "ALUMODE2") ||
-                    // boost::starts_with(n, "ALUMODE3") ||
+                    boost::starts_with(n, "INMODE") ||
+                    boost::starts_with(n, "ALUMODE2") ||
+                    boost::starts_with(n, "ALUMODE3") ||
+                    boost::starts_with(n, "OPMODE6") ||
                     boost::starts_with(n, "CARRYINSEL2") ||
                     boost::starts_with(n, "CED") ||
                     boost::starts_with(n, "CEAD") ||


### PR DESCRIPTION
## Summary

A design whose entire datapath is `assign p = a * b;` returns wrong products on hardware when the multiply is inferred into a DSP48E1. The netlist is correct, post-synthesis simulation of that netlist passes, and timing is clean — the fault is introduced in the FASM writer, so nothing before the bitstream shows it.

Measured on an EBAZ4205 (xc7z010clg400), reading results back over JTAG:

| test | before | after |
|---|---|---|
| two lone 16×16 DSPs, 415 random vectors | 1/315 and 315/315 | **415/415 and 415/415** |
| 32×32 through a 3-DSP cascade, 430 vectors | 25/430 | **430/430** |
| a real compiled kernel that uses a multiply | 965/2016 | **516/516** |

Bit-walk before the fix: sweeping all 16 bits of `A` with `B=1` changed the output **not at all** — one lane returned `0` for every bit, the other a constant `0x18000000`. Sweeping `B` moved the output but to wrong values. After the fix, all 16 A bits and all 16 B bits are exact on both DSPs.

The failure was deterministic and clock-independent — dropping FCLK0 from 100 MHz to 10 MHz reproduced it bit-for-bit — which is what ruled out timing and pointed at the bitstream.

## Cause

Some DSP48E1 site pins have **no interconnect path into the site at all**. In prjxray they appear in `segbits_dsp_{l,r}.db` only as `DSP_<n>_<PIN>.DSP_GND_*` / `DSP_<n>_<PIN>.DSP_VCC_*`, and in no ppips/pips list, so a tile-local constant bit is the only way to give them a value. That set is:

```
D0..D24  RSTD  CARRYINSEL2  CED  CEAD  CEINMODE  CEALUMODE
INMODE0..4  ALUMODE2  ALUMODE3  OPMODE6
```

`pack_dsps()` converted the first seven groups and left `INMODE`, `ALUMODE2/3` and `OPMODE6` out. Those pins stayed on `\$PACKER_VCC_NET`/`\$PACKER_GND_NET` and were handed to the router, which has nowhere to take them. Nothing errors, nothing warns, no bit is emitted — and on silicon the pin comes up as the complement of what the netlist asked for.

For a plain inferred multiply the netlist wants `INMODE=00000`, `OPMODE=0000101`, `ALUMODE=0000`. The part instead sees `INMODE=11111`, `OPMODE=1000101`, `ALUMODE[3:2]=11`:

- **`INMODE[1]=1` gates the multiplier's A operand to zero** (UG479 Table 1-11) — that is the "A does nothing" symptom exactly.
- `OPMODE[6:4]=100` feeds `P` back into the Z mux instead of zero, a combinational loop through the adder, hence the near-constant output.
- `ALUMODE[3:2]=11` changes the ALU function on top of that.

## The second half, in `fasm.cc`

These tile bits **bypass the site's optional input inverter** — the `ZIS_*_INVERTED` bits apply only to the routed pins — so the constant chosen has to be the *logical* value. `write_const_pins()` already tried to do that, but it stripped the digits off the pin name before the parameter lookup, asking for `IS_INMODE_INVERTED` when yosys emits the per-bit `IS_INMODE[1]_INVERTED`. The lookup always returned false, so every bussed pin got the un-flipped constant.

That is almost certainly the `// TODO: these seem to be inverted for unknown reasons` that kept `INMODE`/`ALUMODE2`/`ALUMODE3` commented out of the packer's list in the first place — I can confirm it experimentally: adding the pins **without** fixing the lookup ties them to VCC and makes the DSP strictly worse (fully inert, constant `0x08000000` on every vector). Both halves are needed.

## Commits

1. **`AREG_2_ACASCREG_1` is a conjunction, not `ACASCREG`** — prjxray defines the feature as `(AREG == 2 && ACASCREG == 1)` (`fuzzers/100-dsp-mskpat/generate.py`), but the Z-form bit was derived from `ACASCREG` alone, so the `AREG=1, ACASCREG=1` configuration `synth_xilinx` emits when it absorbs an input register wrote no bit and reads back as `AREG=2`. Found on the way; a latent mis-encoding rather than the cause above — the board result was bit-identical before and after it. Happy to split this out if you would rather review it separately.
2. **The fix above** — the packer's pin list plus the `fasm.cc` lookup.

## Testing

Built with the openXC7 toolchain and run on real hardware (EBAZ4205 / xc7z010clg400, Zynq PS driving the PL over AXI, results read back over JTAG). Numbers in the table above. No change in behaviour for designs without a DSP48E1; for DSP designs the only difference in the emitted FASM is eight added `DSP_<n>_<PIN>.DSP_GND_*` lines per DSP.