### PR TITLE
xc7: relocate CARRY4 O fabric fanout at chain root with constant CIN

### DIFF
--- a/xilinx/pack_carry_xc7.cc
+++ b/xilinx/pack_carry_xc7.cc
@@ -1329,7 +1329,38 @@ void XC7Packer::relocate_carry_o_fabric()
                     continue;
                 if (i == off) {
                     NetInfo *cin = get_net_or_empty(c4, ctx->id("CIN"));
-                    if (cin != nullptr)
+                    // A chain root whose carry-in was a constant has its CIN/CYINIT
+                    // pins disconnected by the PRECYINIT fix in pack_carries().
+                    // The constant value is recorded in PRECYINIT_CONST; use it as
+                    // the sum LUT's CIN input so the root bit's O fabric fanout is
+                    // relocated like any other bit.  Without this, bit 0 keeps an
+                    // O->fabric user alongside CO->fabric (the next bit's sum LUT),
+                    // which violates the single-OUTMUX budget.
+                    if (cin == nullptr) {
+                        if (c4->params.count(ctx->id("PRECYINIT_CONST"))) {
+                            int val = int_or_default(c4->params, ctx->id("PRECYINIT_CONST"), 0);
+                            cin = (val != 0) ? vcc : gnd;
+                        }
+                    }
+                    // Only relocate when bit 0 actually has a fabric O sink that
+                    // contends for OUTMUX; in-position sum FFs are local and do not
+                    // trigger the contention.  This keeps registered adders/counters
+                    // (v4/v10) on the direct XOR->FF path and preserves their fasm.
+                    bool needs_relocate = cin != nullptr;
+                    if (needs_relocate && i == off) {
+                        NetInfo *o = get_net_or_empty(c4, pname("O", i));
+                        if (o != nullptr) {
+                            bool only_ff = true;
+                            for (auto &u : o->users)
+                                if (!(u.port == ctx->id("D") && ff_types.count(u.cell->type))) {
+                                    only_ff = false;
+                                    break;
+                                }
+                            if (only_ff)
+                                needs_relocate = false;
+                        }
+                    }
+                    if (needs_relocate)
                         relocate_sum(c4, i, cin, root);
                 } else {
                     // Includes i == 3: a one-bit split makes bit 3 a new chain


### PR DESCRIPTION
# xc7: relocate CARRY4 O fabric fanout at chain root with constant CIN

Fixes #163.

## What

In `xilinx/pack_carry_xc7.cc`, `relocate_carry_o_fabric()` now handles the case where the lowest bit of a CARRY4 chain has a constant carry-in that was disconnected by the PRECYINIT fix in `pack_carries()`.

When the chain root's `CIN` pin is `nullptr`, the code recovers the constant value from the `PRECYINIT_CONST` cell parameter and uses `$PACKER_VCC_NET` or `$PACKER_GND_NET` as the sum LUT's carry input, so the root bit's `O` fabric fanout is relocated like any other bit.

To keep registered adders/counters bit-identical, the relocation is performed only when bit 0 has a fabric `O` sink that is **not** just the in-position FF.

## Why

The Carry-O relocation pass and the placement-validity rule it answers to both landed with #134. The pass splits a chain when a bit's `O` and `CO` both need fabric; but for the chain-root bit it did:

```cpp
if (i == off) {
    NetInfo *cin = get_net_or_empty(c4, ctx->id("CIN"));
    if (cin != nullptr)
        relocate_sum(c4, i, cin, root);
}
```

A chain root whose carry-in is a constant has its `CIN`/`CYINIT` pins already disconnected by the PRECYINIT fix (the constant lives on in `PRECYINIT_CONST`), so the root bit was skipped. The remaining one-bit split cluster then carries, in the same letter position:

- `O[0]` driving fabric (a LUT/OBUF — any non-FF sink), and
- `CO[0]` driving the relocated sum LUT of the split, placed elsewhere in the fabric.

Both claim the position's single selectable output pin. This is exactly what the per-position site-exit (OUTMUX) budget in `xc7_logic_tile_valid()` rejects (`claims > 1`, `xilinx/arch_place.cc`, the arm added for the O+CO fanout shape in #134). The placer then fails with the user-visible:

```
Carry-O relocation: 3 sum(s) duplicated, 3 CARRY4 split(s), 0 bit(s) skipped (unrelocatable)
ERROR: Unable to find legal placement for cell 'c4', check constraints and utilisation.
```

### Mechanism, verified with `NEXTPNR_DUMP_INVALID_TILE=1` (0.9.3, `68aeeb39`)

Run on the minimal reproducer (explicit CARRY4, `CI=1'b0`, `O`→OBUF, `CO[3]` used) with the unpatched binary:

- With the heap placer, the **only** validity arm that fires is the per-position OUTMUX budget (`invalid-arm: line 502` = the `claims > 1` reject; 13534 occurrences, no other arm) before `Unable to find legal placement for cell 'c4'`.
- With `--placer sa`, the final tile dump shows the rejected tile's **sole occupant** is the one-bit root CARRY4 (`tile occupant: SLICE_X53Y48/CARRY4 = c4`, eighth 4) — no LUT and no FF share the position. Revalidation of that tile fires the same arm. With a lone CARRY4 in the tile, the only way to reach two OUTMUX claims is its own `O` (external fabric sink) plus its own `CO` (used, non-local) — confirming the contention is `O[0]`→fabric against `CO[0]`→split-sum-LUT, as the fix assumes.

The trigger in the wild is a `CO` that leaves the chain into fabric. RTL-inferred adders/counters are immune: yosys emits the carry-out as an extra sum bit on `O`, never as `CO` to fabric, and a `CO[3]` feeding only the next CARRY4's `CIN` rides the dedicated COUT spine. The failing shape is an explicitly instantiated CARRY4 (or generated core) using `CO` as a fabric output while the lowest-bit `O` leaves the slice.

## How

The change is localized to the `i == off` branch in `relocate_carry_o_fabric()`:

1. If `CIN` is disconnected, look up `PRECYINIT_CONST`.
2. Set `cin` to `vcc` or `gnd` accordingly.
3. Check whether bit 0's `O` net has any user that is **not** an FF `D` input in position; if all users are in-position FFs, skip relocation to preserve the direct XOR→FF path.
4. Call `relocate_sum()` with the recovered constant net when relocation is needed.

## Validation

All nextpnr runs use `--placer heap --seed 1`. The patched binary was validated **inside a copy of the released 0.9.3 package** (`apio-openxc7-linux-x86-64`, release 2026-08-20) with only `libexec/nextpnr-xilinx` substituted.

### Severity variants (xc7a35tcsg324)

| Variant | 0.9.3 rc | patched rc |
|---|---|---|
| v1 (baseline) | 255 | 0 |
| v2 (S from LUT) | 255 | 0 |
| v3 (CO open) | 0 | 0 |
| v4 (O -> FF) | 0 | 0 |
| v5 (8 bit) | 255 | 0 |
| v6 (O -> LUT -> FF) | 255 | 0 |
| v7 (O -> LUT -> OBUF) | 255 | 0 |
| v8 (RTL adder, s combo) | 0 | 0 |
| v9 (RTL adder, s reg) | 0 | 0 |
| v10 (counter tc) | 0 | 0 |
| v11_16 | 0 | 0 |
| v11_32 | 0 | 0 |

- `fasm2frames` accepts every patched fasm.
- v3/v4/v9/v10 fasm are byte-identical to 0.9.3 (`cmp`).

### Large benchmarks

| Design | Part | 0.9.3 rc | patched rc | fasm vs 0.9.3 |
|---|---|---|---|---|
| litex-ddr-arty-s7 main | xc7s50csga324 | 0 | 0 | byte-identical |
| litex-ddr-arty-s7 deephier | xc7s50csga324 | 0 | 0 | byte-identical |
| picosoc (220 CARRY4) | xc7k325tffg676 | 0 | 0 | byte-identical (83,303 lines) |
| congestion-local (no carry) | xc7a35tcsg324 | 0 | 0 | byte-identical (209,396 lines) |

### Regression suite (tools-openxc7 `regress/`, yosys from the oss-cad-suite revision in `lock.json`)

Patched package copy vs unpatched 0.9.3 package, same runner machine:

- All tier ≤2 tests on xc7a35tcsg324 (22 tests), plus `carry64`, `carry-const-di`, `srl-cascade`, `srl-cascade-deep` on xc7s50csga324.
- **Every measured metric is identical** between the two runs (fmax, LUT/FF/BRAM/DSP counts; pnr seconds within machine noise).
- **Every produced fasm is byte-identical** between the two runs — raw `cmp`, including the identity header — for all 20 routed a35t tests and all 4 s50 tests. The patch leaves no trace on any design the suite exercises.
- Two tests failed identically with both binaries for reasons unrelated to the patch (a stale expected-fail declaration in the runner's copy of the suite — the current suite already expects `carry-const-di` to pass, and it does with both binaries with identical fasm — and a board demo forced onto a different package by `--part`); neither output differs between the two runs.

## Checklist

- [x] Root cause identified and explained; rejecting rule verified at mechanism level (`NEXTPNR_DUMP_INVALID_TILE=1`).
- [x] Minimal reproducer included.
- [x] Patch validated against the failing package (0.9.3), inside a package copy.
- [x] Existing healthy designs (v3/v4/v9/v10, litex, picosoc, congestion-local) keep identical fasm.
- [x] Regression suite run on two parts; metrics and fasm identical to the unpatched package.