### PR TITLE
xc7: emit `BUFIO_Yn.IN_USE` for a placed BUFIO (+ prjxray-db bump)

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2562,6 +2562,49 @@ struct FasmBackend
         pop();
     }
 
+    // A placed BUFIO emits nothing today, so the buffer is never switched on.
+    //
+    // #157 gave BUFIO a packer -- the cell is renamed to BUFIO_BUFIO and binds
+    // to the bel -- and from then on a design places and routes.  The clock
+    // reaches the site and leaves it through ordinary tile routing, which
+    // write_pip already emits:
+    //
+    //     HCLK_IOI3_X113Y78.HCLK_IOI_IO_PLL_CLK0_DMUX.HCLK_IOI_I2IOCLK_TOP0
+    //     HCLK_IOI3_X113Y78.HCLK_IOI_IOCLK0.HCLK_IOI_BUFIO_O0
+    //
+    // What is missing is the enable.  prjxray-db carries two bits per slot,
+    //
+    //     HCLK_IOI3.BUFIO_Y0.IN_USE 36_16 36_18
+    //     HCLK_IOI3.BUFIO_Y1.IN_USE 37_16 37_18
+    //     HCLK_IOI3.BUFIO_Y2.IN_USE 36_31 37_31
+    //     HCLK_IOI3.BUFIO_Y3.IN_USE 36_21 37_22
+    //
+    // (segbits_hclk_ioi3.db, added by openXC7/prjxray-db#7 from a
+    // 039-hclk-config campaign; the rows come out identical whether the BUFIO
+    // is fed from a clock-capable pad or from the region's MMCM, so they are
+    // an enable and not a record of the route).  Without them the bitstream
+    // assembles with those bits clear: valid-looking, and the I/O clock never
+    // starts -- the same silent-death shape as the RCLK2IO leaf that the same
+    // database change fixed on the BUFR side.
+    //
+    // Emitted from the cell for the reason given above write_bufr: the
+    // configuration belongs to the instance, and the pseudo-pip table only
+    // fires when the site is crossed as routing rather than occupied.
+    void write_bufio(CellInfo *ci)
+    {
+        // Site name is BUFIO_X0Y<y> and the feature is BUFIO_Y<y>, where the
+        // index is the site's y within its tile -- the same convention BUFR
+        // uses above, and the one the fuzzer used to mint the rows (the site's
+        // y minus the lowest BUFIO y of the tile).
+        auto xy = ctx->getSiteLocInTile(ci->bel);
+
+        push(get_tile_name(ci->bel.tile));
+        push("BUFIO_Y" + std::to_string(xy.y));
+        write_bit("IN_USE");
+        pop();
+        pop();
+    }
+
     void write_pll(CellInfo *ci)
     {
         push(get_tile_name(ci->bel.tile));
@@ -5270,6 +5313,11 @@ void write_gtx_channel(CellInfo *ci)
             }
             if (ci->type == id_BUFR_BUFR && ci->bel != BelId()) {
                 write_bufr(ci);
+                blank();
+                continue;
+            }
+            if (ci->type == id_BUFIO_BUFIO && ci->bel != BelId()) {
+                write_bufio(ci);
                 blank();
                 continue;
             }


### PR DESCRIPTION
Closes the configuration half of #149 for BUFIO.

With #157 a `BUFIO` cell packs onto the `BUFIO_BUFIO` bel, so a design places and routes and the tile routing pips that carry the clock in and out are emitted. Nothing turns the buffer on: no `BUFIO_Y*` feature appears anywhere in the FASM. The bitstream assembles and is dead on silicon — the same shape as #150 and as the `RCLK2IO` leaf that prjxray-db#7 fixed on the BUFR side.

## Two commits

**1. `build: bump prjxray-db submodule to 77e52f10`** — the merge of [openXC7/prjxray-db#7](https://github.com/openXC7/prjxray-db/pull/7). Nothing here depends on `77e52f10` being the tip; it is the first revision that carries the three HCLK_IOI3 changes this issue needs. Drop this commit if the submodule has already moved past it.

**2. `xc7: emit BUFIO_Yn.IN_USE for a placed BUFIO`** — 48 lines in `xilinx/fasm.cc`, 32 of them comment, a `write_bufio()` symmetric to the `write_bufr()` directly above it, plus its dispatch line in `write_ip()`.

## The feature, quoted from the database

`artix7/segbits_hclk_ioi3.db` at `77e52f10`:

```
HCLK_IOI3.BUFIO_Y0.IN_USE 36_16 36_18
HCLK_IOI3.BUFIO_Y1.IN_USE 37_16 37_18
HCLK_IOI3.BUFIO_Y2.IN_USE 36_31 37_31
HCLK_IOI3.BUFIO_Y3.IN_USE 36_21 37_22
```

The slot index is the site's y within its tile — `BUFIO_X0Y9` in a tile whose lowest BUFIO is `BUFIO_X0Y8` is `BUFIO_Y1`. That is `getSiteLocInTile().y`, the same quantity `write_bufr` uses, and the same one the fuzzer used to mint the rows (`fuzzers/039-hclk-config/generate.py`: `y = site_y - y_min`).

## Two things this PR deliberately does *not* add, because they already work

Both were on my list and both turned out to need no code, which is worth recording since #149 says otherwise:

**The `RCLK2IO` leaf** is an ordinary tile-routing pip and `write_pip` already emits it. Measured on the BUFR probe from #149, identical before and after this patch:

```
HCLK_IOI3_X113Y78.HCLK_IOI_RCLK2IO3.HCLK_IOI_CK_BUFRCLK3
```

What changed is underneath it: that line used to resolve against a `ppips_hclk_ioi3.db` entry marked `always` and set nothing. prjxray-db#7 retired the four `always` entries and gave the leaf its bit (`28_17` for RCLK3), so commit 1 alone closes that silent failure.

**The DMUX I2IOCLK position** is likewise already emitted as routing (`HCLK_IOI3_X113Y78.HCLK_IOI_IO_PLL_CLK0_DMUX.HCLK_IOI_I2IOCLK_TOP0`). Before prjxray-db#7 it was the key `fasm2frames` died on; it now resolves as a `default` pseudo-pip, which sets nothing because the position is the all-zero one — measured, not assumed (`SRC_CCIO` resolved to zero candidates on all four sites across 100 specimens).

## Verified

xc7a35tcsg324-1, prjxray-db `77e52f10`, `--router router2`; **base** = `7cfd1e90` (current main), **fix** = base + these two commits. One factor between the two runs: the binary.

**The chipdb does not move with the submodule bump.** `bbaexport.py` reads `tile_type_*.json`, `tilegrid.json`, `tileconn.json`, `package_pins.csv` and the metadata tree; prjxray-db#7 touches only `segbits`/`ppips`/`mask`/`origin_info`. Generated both ways from the same tree, the `.bin` is byte-identical:

```
04803defd62c99ef1f30b539a85185cb5a7055553eaa50d7b13ab4b78647a6cf  chipdb (prjxray-db e5eab650)
04803defd62c99ef1f30b539a85185cb5a7055553eaa50d7b13ab4b78647a6cf  chipdb (prjxray-db 77e52f10)
```

**One probe per slot of `HCLK_IOI3_X113Y78`.** Pad → IBUF → BUFIO → ODDR, the shape of `bufio_top.v` from #149, four times with the pad and the BUFIO site varied. Each run goes FASM → `fasm2frames` → `xc7frames2bit` → `bit2fasm`:

| slot | pad | site | FASM added vs base | frame bits added | read back by `bit2fasm` |
|---|---|---|---|---|---|
| Y0 | E2 (`IOB_X1Y72`) | `BUFIO_X1Y4` | `…BUFIO_Y0.IN_USE` | `0x15a4` w50 b16, b18 | yes (base: none) |
| Y1 | F4 (`IOB_X1Y74`) | `BUFIO_X1Y5` | `…BUFIO_Y1.IN_USE` | `0x15a5` w50 b16, b18 | yes (base: none) |
| Y2 | E3 (`IOB_X1Y76`) | `BUFIO_X1Y6` | `…BUFIO_Y2.IN_USE` | `0x15a4` w50 b31, `0x15a5` w50 b31 | yes (base: none) |
| Y3 | D5 (`IOB_X1Y78`) | `BUFIO_X1Y7` | `…BUFIO_Y3.IN_USE` | `0x15a4` w50 b21, `0x15a5` w50 b22 | yes (base: none) |

Exactly one FASM line and exactly two frame bits per probe, and the addresses are the database rows arithmetically: the tile's `tilegrid.json` entry is `baseaddr 0x00001580`, `offset 50`, `words 1`, so segbit `36_16` is frame `0x1580+36 = 0x15a4`, word `50`, bit `16`. All four rows land where they should.

**Against the fuzzer's own measurement.** The rows come from `039-hclk-config` (openXC7/prjxray#8) run on Vivado bitstreams for xc7a100tfgg676-1; the bits above are ours, assembled by prjxray on xc7a35tcsg324-1. Raw `segdata_hclk_ioi3.txt` of specimen 1 of that campaign, segment `00001C80_050`, `BUFIO_Y2=1 BUFIO_Y3=1 BUFIO_Y0=0 BUFIO_Y1=0`:

```
bit 36_21   bit 36_31   bit 37_21   bit 37_22   bit 37_31   (…)
```

`36_31 37_31` for Y2 and `36_21 37_22` for Y3, and neither of Y0/Y1's bits. The segment where Y0 and Y1 are the used pair carries `36_16 36_18 37_16 37_18` instead. Vendor bitstream and our assembled frames agree bit for bit.

**No BUFR regression.** The two BUFR probes from #149 (`BUFR_DIVIDE("5")` and `("BYPASS")`) produce byte-identical FASM and byte-identical frames before and after, and `bit2fasm` reads `BUFR_Y1.IN_USE` + the right divider back out of both bitstreams.

**No change to anything without a BUFIO.** Regression suite tier ≤2 inside a copy of the openXC7 0.9.3 package with only the nextpnr binary swapped — 36 runs (tiers 1 and 2, every part each test declares), **0 FAIL**, and the canonical FASM is identical in all 35 designs that produce one — the 36th is the known kintex7 expected-fail. Every recorded metric (fmax, LUTs, FFs, BRAMs, DSPs) is identical too. The raw files differ only in the `#` identity header, which carries the binary's version string.

## One thing that is still missing, and is not this PR

A pad-fed BUFIO only routes on its **dedicated** site, and nothing constrains the placer to pick it — it takes any free `BUFIO_BUFIO` bel. Sweeping the four clock-capable master pads of bank 35 against the four BUFIO sites of their tile, on `7cfd1e90`:

| pad | `BUFIO_X1Y4` | `BUFIO_X1Y5` | `BUFIO_X1Y6` | `BUFIO_X1Y7` |
|---|---|---|---|---|
| E2 `IOB_X1Y72` | **routes** | fails | fails | fails |
| F4 `IOB_X1Y74` | fails | **routes** | fails | fails |
| E3 `IOB_X1Y76` | fails | fails | **routes** | fails |
| D5 `IOB_X1Y78` | fails | fails | fails | **routes** |

One site per pad, in pad order — the CCIO→BUFIO bijection the 039 campaign measured on xc7a100t (24/24), here confirmed independently from nextpnr's own routing graph. Left free, the placer chose `BUFIO_X1Y5` for three of those pads and `BUFIO_X1Y4` for the fourth: **0 of 4 route**, each dying with

```
ERROR: Failed to route arc 0 of net 'clk_ibuf',
       from SITEWIRE/IOB_X1Y76/INBUF_EN_OUT to SITEWIRE/BUFIO_X1Y5/I.
```

So the four probes above are constrained with `(* BEL = "BUFIO_X1Y6/BUFIO" *)` to isolate the FASM question from the placement one. Picking the site from the routing graph at pack time is the remaining piece of #149; it belongs in `pack_clocking_xc7.cc`, not here, and I would rather land the emission — which is complete and measured — than hold it behind a second change.

## Credit, and one correction

@gHashTag wrote the BUFIO packer (#157) and every probe this is verified with, including the BUFIO one written specifically because the BUFR pair covered only the half of #149 that was already fixed.

One thing in the #157 thread needs updating rather than leaving to be found. The comment there concluded that BUFIO has no enable bit — "no `segbits_*.db` file mentions it at all", four `always` pseudo-pips and nothing else — and it was right about `master` as published on 2026-08-20. The four rows were sitting in prjxray-db#7 at the time, open since 2026-08-18 and merged on 2026-08-26. So the caveat that comment withdrew was the correct one after all: a design could reach a bitstream with the buffer off. That conclusion was explicitly marked there as an inference from the database rather than from silicon, which is exactly why it is easy to correct now.

The rows themselves are the output of the `039-hclk-config` extension (openXC7/prjxray#8) and prjxray-db#7 carries them; my own published prediction about the neighbouring I2IOCLK bits died to that same campaign.
