### PR TITLE
xc7: place a pad-fed BUFIO on the site its pad can reach

### DIFF
--- a/xilinx/pack.h
+++ b/xilinx/pack.h
@@ -248,6 +248,9 @@ struct XC7Packer : public XilinxPacker
     void prepare_clocking();
     void pack_plls();
     void pack_gbs();
+    // Bind every pad-fed BUFIO to the one site its pad can reach; run from
+    // pack_gbs(), after pack_io() has placed the pads.
+    void constrain_bufios();
     void pack_clocking();
 
     // CFG

--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -377,39 +377,53 @@ void XC7Packer::constrain_bufios()
 {
     for (auto cell : sorted(ctx->cells)) {
         CellInfo *ci = cell.second;
-        if (ci->type != id_BUFIO_BUFIO)
+        const bool is_bufio = (ci->type == id_BUFIO_BUFIO);
+        if (!is_bufio)
             continue;
+
         NetInfo *clk = get_net_or_empty(ci, id_I);
-        if (clk == nullptr || clk->driver.cell == nullptr)
+        const bool has_driven_input = (clk != nullptr && clk->driver.cell != nullptr);
+        if (!has_driven_input)
             continue;
+
         CellInfo *drv = clk->driver.cell;
         // Only a pad fixes the site.  A BUFIO driven by an MMCM/PLL output, or
         // by anything else, enters the tile through a different DMUX leg and is
         // left exactly as it was.  pack_io() has already given every input
         // buffer its bel by now (decompose_iob() writes <site>/IOB33/INBUF_EN),
         // which is what makes the pad knowable this early.
-        if (!boost::contains(drv->type.str(ctx), "INBUF") || !drv->attrs.count(id_BEL))
+        const bool driven_by_input_buffer = boost::contains(drv->type.str(ctx), "INBUF");
+        const bool driver_is_placed = drv->attrs.count(id_BEL) > 0;
+        if (!driven_by_input_buffer || !driver_is_placed)
             continue;
+
         BelId pad_bel = ctx->getBelByName(ctx->id(drv->attrs.at(id_BEL).as_string()));
-        if (pad_bel == BelId())
+        const bool pad_bel_is_known = (pad_bel != BelId());
+        if (!pad_bel_is_known)
             continue;
+
         BelId dedicated =
                 find_bel_with_short_route(ctx->getBelPinWire(pad_bel, clk->driver.port), ci->type, id_I);
         // No BUFIO reachable: the pad is not clock-capable.  Leave that to the
         // router, whose message names the two ends of the arc it could not
         // build; guessing a site here would only move the failure.
-        if (dedicated == BelId())
+        const bool pad_reaches_a_bufio = (dedicated != BelId());
+        if (!pad_reaches_a_bufio)
             continue;
-        if (ci->attrs.count(id_BEL)) {
+
+        const bool user_chose_a_site = ci->attrs.count(id_BEL) > 0;
+        if (user_chose_a_site) {
             // A site the user wrote wins, but check it against the graph rather
             // than let a wrong one turn into a routing failure an hour later.
             // A name that does not resolve is not ours to report: the placer
             // already says "No Bel named ..." for that.
             const std::string want = ci->attrs.at(id_BEL).as_string();
             BelId want_bel = ctx->getBelByName(ctx->id(want));
-            if (want_bel == dedicated)
+            const bool user_site_is_the_dedicated_one = (want_bel == dedicated);
+            const bool user_site_resolves = (want_bel != BelId());
+            if (user_site_is_the_dedicated_one)
                 used_bels.insert(dedicated);
-            else if (want_bel != BelId())
+            else if (user_site_resolves)
                 log_error("BUFIO '%s' is constrained to bel '%s', which the pad driving it cannot reach; "
                           "the BUFIO of that pad (%s) is '%s'.\n",
                           ctx->nameOf(ci), want.c_str(), ctx->nameOfBel(pad_bel), ctx->nameOfBel(dedicated));

--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -344,6 +344,82 @@ void XC7Packer::pack_gbs()
         }
         log_info("    BUFGCTRL: disconnected %d const control pins (config-tied, not routed)\n", n);
     }
+
+    // A BUFIO is a regional I/O clock buffer rather than a global one, but this
+    // is where the clock buffers get their bels and it has to run after
+    // pack_io() has placed the pads it reads.
+    constrain_bufios();
+}
+
+// A BUFIO is not placed wherever there is room: it is placed where the pad
+// says.  Its I pin has no fabric input at all -- the only wire that reaches it
+// is the I2IOCLK leg its own clock-capable pad drives into the HCLK_IOI tile --
+// so of the four BUFIO_BUFIO bels of a tile exactly ONE is reachable from a
+// given pad.  Sweeping the four master clock-capable pads of bank 35 of an
+// xc7a35tcsg324-1 against the four BUFIO sites of their tile gives a diagonal:
+// E2 routes only on BUFIO_X1Y4, F4 only on X1Y5, E3 only on X1Y6, D5 only on
+// X1Y7 -- the CCIO->BUFIO bijection prjxray's 039-hclk-config campaign measured
+// on silicon bitstreams, here read back out of our own routing graph.
+//
+// Nothing told the placer that.  #157 packs the cell onto a BUFIO_BUFIO bel and
+// the placer takes any free one, so a pad-fed BUFIO dies in the router:
+//
+//   ERROR: Failed to route arc 0 of net 'clk_ibuf',
+//          from SITEWIRE/IOB_X1Y76/INBUF_EN_OUT to SITEWIRE/BUFIO_X1Y5/I.
+//
+// (0 of those 4 probes routed; the placer picked X1Y5 for three of the pads.)
+//
+// So ask the routing graph which bel the pad reaches -- the same pip BFS
+// try_preplace() runs for a BUFG -- and constrain the cell to it.  A table of
+// pad->site pairs would answer the same question for artix7 today and be wrong
+// for the next family; the graph is per-part data and already knows.
+void XC7Packer::constrain_bufios()
+{
+    for (auto cell : sorted(ctx->cells)) {
+        CellInfo *ci = cell.second;
+        if (ci->type != id_BUFIO_BUFIO)
+            continue;
+        NetInfo *clk = get_net_or_empty(ci, id_I);
+        if (clk == nullptr || clk->driver.cell == nullptr)
+            continue;
+        CellInfo *drv = clk->driver.cell;
+        // Only a pad fixes the site.  A BUFIO driven by an MMCM/PLL output, or
+        // by anything else, enters the tile through a different DMUX leg and is
+        // left exactly as it was.  pack_io() has already given every input
+        // buffer its bel by now (decompose_iob() writes <site>/IOB33/INBUF_EN),
+        // which is what makes the pad knowable this early.
+        if (!boost::contains(drv->type.str(ctx), "INBUF") || !drv->attrs.count(id_BEL))
+            continue;
+        BelId pad_bel = ctx->getBelByName(ctx->id(drv->attrs.at(id_BEL).as_string()));
+        if (pad_bel == BelId())
+            continue;
+        BelId dedicated =
+                find_bel_with_short_route(ctx->getBelPinWire(pad_bel, clk->driver.port), ci->type, id_I);
+        // No BUFIO reachable: the pad is not clock-capable.  Leave that to the
+        // router, whose message names the two ends of the arc it could not
+        // build; guessing a site here would only move the failure.
+        if (dedicated == BelId())
+            continue;
+        if (ci->attrs.count(id_BEL)) {
+            // A site the user wrote wins, but check it against the graph rather
+            // than let a wrong one turn into a routing failure an hour later.
+            // A name that does not resolve is not ours to report: the placer
+            // already says "No Bel named ..." for that.
+            const std::string want = ci->attrs.at(id_BEL).as_string();
+            BelId want_bel = ctx->getBelByName(ctx->id(want));
+            if (want_bel == dedicated)
+                used_bels.insert(dedicated);
+            else if (want_bel != BelId())
+                log_error("BUFIO '%s' is constrained to bel '%s', which the pad driving it cannot reach; "
+                          "the BUFIO of that pad (%s) is '%s'.\n",
+                          ctx->nameOf(ci), want.c_str(), ctx->nameOfBel(pad_bel), ctx->nameOfBel(dedicated));
+            continue;
+        }
+        used_bels.insert(dedicated);
+        ci->attrs[id_BEL] = std::string(ctx->nameOfBel(dedicated));
+        log_info("    Constrained BUFIO '%s' to bel '%s' (dedicated site of the pad at %s)\n", ctx->nameOf(ci),
+                 ctx->nameOfBel(dedicated), ctx->nameOfBel(pad_bel));
+    }
 }
 
 void XC7Packer::pack_clocking()


### PR DESCRIPTION
One file plus a declaration, on top of `main` as of #167 (it needs the `BUFIO_Yn.IN_USE` emission and the prjxray-db bump that PR carries, both merged this morning — thanks). The commit was written and measured on the tip of #167 and rebased onto `main` unchanged (`range-diff` clean); CI here builds the rebased tree.

Closes the placement half of #149 for BUFIO.

## The problem

#157 made a `BUFIO` cell pack: it is renamed to the `BUFIO_BUFIO` bel type and the placer binds it to a free bel of that type. Any free one. But a BUFIO's `I` pin has no fabric input at all — the only wire that reaches it is the `I2IOCLK` leg its own clock-capable pad drives into the `HCLK_IOI` tile — so of the four `BUFIO_BUFIO` bels in a tile exactly **one** is reachable from a given pad, and the placer does not know that. The BUFIO probe from #149, run unmodified, dies in the router:

```
ERROR: Failed to route arc 0 of net 'clk_ibuf',
       from SITEWIRE/IOB_X1Y76/INBUF_EN_OUT to SITEWIRE/BUFIO_X1Y5/I.
```

Four clock-capable master pads of bank 35 of an xc7a35tcsg324-1, each with the BUFIO left free: **0 of 4 route**. The placer took `BUFIO_X1Y5` twice, `BUFIO_X1Y4` once and `BUFIO_X1Y6` once, and never the site the pad in question owns — it has no reason to prefer one. Today the design only works if the user writes `(* BEL = "BUFIO_X1Y6/BUFIO" *)` themselves, having first worked out which site that is.

## The change

`XC7Packer::constrain_bufios()`, called from `pack_gbs()` after `pack_io()` has placed the pads. For every `BUFIO_BUFIO` cell whose `I` net is driven by an input buffer, it follows the routing graph from the buffer's output bel pin wire to the one `BUFIO_BUFIO` bel whose `I` pin it reaches, and writes that bel as the cell's `BEL` attribute — the same `find_bel_with_short_route()` pip BFS `try_preplace()` already runs to place a BUFG next to its pad, and the same constraint mechanism.

- A BUFIO fed from anything that is not an input buffer (an MMCM/PLL output, most of all) is not touched.
- A `BEL` the user wrote wins, but it is checked: if the pad cannot reach it, the packer says so, naming both sites, instead of letting it become a routing failure an hour later.
- A pad that is not clock-capable reaches no BUFIO at all; the cell is left alone and the router's own message stands.

Read from the graph rather than from a table on purpose. A pad→site table would be right for artix7 today and wrong for the next family; the graph is per-part data that already knows, and the same code picks the right site on spartan7, zynq7 and kintex7 chipdbs without a line about any of them (measured below).

## Verified

xc7a35tcsg324-1, prjxray-db `77e52f10`, `--router router2`. **base** = the tip of #167 (`c52d41b6`, now in `main`), **fix** = base + this commit; one factor between the arms: the binary.

### The four clock-capable master pads of bank 35, BUFIO left free

| pad | pad site | base | fix | site the packer chose | FASM |
|---|---|---|---|---|---|
| E2 | `IOB_X1Y72` | fails on `BUFIO_X1Y6` | **routes** | `BUFIO_X1Y4` | `HCLK_IOI3_X113Y78.BUFIO_Y0.IN_USE` |
| F4 | `IOB_X1Y74` | fails on `BUFIO_X1Y4` | **routes** | `BUFIO_X1Y5` | `…BUFIO_Y1.IN_USE` |
| E3 | `IOB_X1Y76` | fails on `BUFIO_X1Y5` | **routes** | `BUFIO_X1Y6` | `…BUFIO_Y2.IN_USE` |
| D5 | `IOB_X1Y78` | fails on `BUFIO_X1Y5` | **routes** | `BUFIO_X1Y7` | `…BUFIO_Y3.IN_USE` |

0 of 4 before, 4 of 4 after, each on its own site, in pad order — the CCIO→BUFIO bijection prjxray's `039-hclk-config` campaign measured on silicon bitstreams, here picked out of nextpnr's own routing graph. The packer says which and why:

```
Info:     Constrained BUFIO 'bufio_inst' to bel 'BUFIO_X1Y6/BUFIO'
          (dedicated site of the pad at IOB_X1Y76/IOB33/INBUF_EN)
```

All four go the whole way — `fasm2frames` → `xc7frames2bit` → `bit2fasm` reads the right `BUFIO_Y<n>.IN_USE` back out of each bitstream.

### One reachable bel, not a shortest-path guess

`find_bel_with_short_route()` returns the nearest match and tie-breaks by lowest y, which would matter if a pad could reach two BUFIOs. It cannot. Instrumented to keep expanding instead of returning at the first hit, run from each of the four pads (E2 quoted):

```
[scan] 1 match(es) of BUFIO_BUFIO after 779 wires:  BUFIO_X1Y4/BUFIO
[scan] END: 318753 wires visited, frontier hit the cap
```

One match, at ~780 wires, and no second `BUFIO_BUFIO` anywhere in the next 300k wires of reachable graph. Same for all four pads. The graph answers the question outright; nothing here rests on the tie-break.

### The probe from #149, unmodified

`bufio_top.v` and `bufr_probe.xdc` byte for byte as published in [gHashTag/trinity-fpga](https://github.com/gHashTag/trinity-fpga/blob/main/research/bufr-probe/bufio_top.v) (pad E3), with no `BEL` attribute added:

| | base | fix |
|---|---|---|
| P&R | `Failed to route arc 0 of net 'clk_ibuf'` | routes on `BUFIO_X1Y6` |
| bitstream | — | 2192114 bytes, `bit2fasm` reads `HCLK_IOI3_X113Y78.BUFIO_Y2.IN_USE` |

### What is deliberately unchanged

- **BUFIO fed from an MMCM** (`IBUF → MMCME2_BASE → BUFIO → ODDR`): routes on both arms, canonical FASM identical, 93 lines. The MMCM legs of the DMUX are a different question and this PR does not touch them.
- **A pad that is not clock-capable** (A4, `IO_L8P_T1_AD14P_35`): the packer constrains nothing and both arms stop with the same router message.
- **A `BEL` that agrees with the graph** (E3 constrained to `BUFIO_X1Y6`): canonical FASM identical to base, 39 lines.
- **A `BEL` that does not**: E3 constrained to `BUFIO_X1Y5` stops at pack time with

  ```
  ERROR: BUFIO 'bufio_inst' is constrained to bel 'BUFIO_X1Y5/BUFIO', which the pad
         driving it cannot reach; the BUFIO of that pad (IOB_X1Y76/IOB33/INBUF_EN)
         is 'BUFIO_X1Y6/BUFIO'.
  ```

### Other families, no code about them

The same probe, same binary, the chipdb of another part:

| part | family | pad | base | fix |
|---|---|---|---|---|
| xc7s50csga324-1 | spartan7 | C1, HR bank 35 | fails on `BUFIO_X1Y5` | routes, `BUFIO_X1Y6` |
| xc7z020clg400-1 | zynq7 | U18, HR bank 34 | routes (the placer happened to pick it) | routes, `BUFIO_X1Y6` |
| xc7k70tfbg484-1 | kintex7 | R3, **HP** bank 34 | fails on `BUFIO_X1Y7` | routes, `BUFIO_X1Y6` |

The kintex7 row is the one that exercises a different tile: an HP-bank pad is an `IOB18` whose regional clock tile is `HCLK_IOI`, not the `HCLK_IOI3` of every HR bank, and the FASM lands there — `HCLK_IOI_X115Y78.BUFIO_Y2.IN_USE`, from a `IOB_X1Y76/IOB18/INBUF_DCIEN` pad. Nothing in the patch names a tile type, a family or a part.

The zynq7 case is the other interesting one: with the BUFIO free the placer picked the dedicated site by luck, and base and fix produce identical FASM. The change turns that luck into a decision.

All three stop later, at `fasm2frames`, and not for a reason this PR can fix:

```
Segment DB HCLK_IOI3, key HCLK_IOI3.HCLK_IOI_IO_PLL_CLK0_DMUX.HCLK_IOI_I2IOCLK_TOP0 not found
Segment DB HCLK_IOI3, key HCLK_IOI3.BUFIO_Y2.IN_USE not found
```

(kintex7 says the same about `HCLK_IOI`.) Those rows exist in prjxray-db for **artix7 only** — they are what [prjxray-db#7](https://github.com/openXC7/prjxray-db/pull/7) added there, out of the `039-hclk-config` campaign. spartan7, zynq7 and kintex7 have neither. So a BUFIO design places and routes on those families today and cannot be assembled; that is a database gap, worth its own issue, and it is orthogonal to placement.

### Nothing without a BUFIO changes

Regression suite tier ≤2 inside a copy of the openXC7 0.9.3 package with only `bin/nextpnr-xilinx` swapped between the two arms, and the bundled prjxray-db replaced by `77e52f10` in both:

```
base: {'WARN': 35, 'OK': 1}  total 36  FAILs: []
fix : {'WARN': 35, 'OK': 1}  total 36  FAILs: []
canonical FASM identical: 35   differing: 0   missing: 0
```

36 runs (both tiers, every part each test declares), **0 FAIL**, and the canonical FASM identical in all 35 designs that produce one — the 36th is the known kintex7 expected-fail. Every recorded metric is identical between the arms as well (bitstream size, fmax, LUTs, FFs, BRAMs, DSPs; only the P&R wall time moves). The 35 `WARN`s are "baseline recorded with different tool versions", in both arms alike: the baselines were recorded with the release binary, these are dev builds. No test in the suite instantiates a BUFIO, which is the point — the new code only runs when a BUFIO is fed from a pad.

## Credit

@gHashTag wrote the BUFIO packer (#157) and the probe this is measured with. The CCIO→BUFIO bijection it relies on was measured by the `039-hclk-config` extension (openXC7/prjxray#8), on Vivado bitstreams, before nextpnr's graph was asked the same question here.

## Still not done, and not this PR

The `HCLK_L` third of #149: `segbits_hclk_l.db` carries only `ENABLE_BUFFER.HCLK_CK_BUFHCLK8..11` — no `BUFRCLK` rows at all — and `fasm.cc` filters used sources with `boost::contains(s, "BUFHCLK")`, so a used `HCLK_CK_BUFRCLK<n>` would be dropped even if the rows existed. Two gaps, one on each side, and no probe of mine produces a single `HCLK_L` line to start from.
