### PR TITLE
xilinx: constrain a pad-fed BUFR to its dedicated site, as #168 does for BUFIO

### DIFF
--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -377,8 +377,19 @@ void XC7Packer::constrain_bufios()
 {
     for (auto cell : sorted(ctx->cells)) {
         CellInfo *ci = cell.second;
-        const bool is_bufio = (ci->type == id_BUFIO_BUFIO);
-        if (!is_bufio)
+        // A pad-fed BUFR carries the same constraint as a BUFIO, for the same
+        // reason: its I pin is reached only by the I2IOCLK leg of its own
+        // clock-capable pad, so one site of the tile is right and the rest are
+        // unroutable.  xc7a35t hides this -- few sites, the placer guesses
+        // right -- but on an xc7a200tfbg484-2 with the pad at R4 it fails
+        // exactly as a BUFIO did before #168:
+        //
+        //   ERROR: Failed to route arc 0 of net 'clk_ibuf'
+        //
+        // Everything below reads ci->type, so the same graph walk answers for
+        // both buffer types.
+        const bool is_regional_buffer = (ci->type == id_BUFIO_BUFIO || ci->type == id_BUFR_BUFR);
+        if (!is_regional_buffer)
             continue;
 
         NetInfo *clk = get_net_or_empty(ci, id_I);
@@ -424,15 +435,16 @@ void XC7Packer::constrain_bufios()
             if (user_site_is_the_dedicated_one)
                 used_bels.insert(dedicated);
             else if (user_site_resolves)
-                log_error("BUFIO '%s' is constrained to bel '%s', which the pad driving it cannot reach; "
-                          "the BUFIO of that pad (%s) is '%s'.\n",
-                          ctx->nameOf(ci), want.c_str(), ctx->nameOfBel(pad_bel), ctx->nameOfBel(dedicated));
+                log_error("%s '%s' is constrained to bel '%s', which the pad driving it cannot reach; "
+                          "the dedicated site of that pad (%s) is '%s'.\n",
+                          ci->type.c_str(ctx), ctx->nameOf(ci), want.c_str(), ctx->nameOfBel(pad_bel),
+                          ctx->nameOfBel(dedicated));
             continue;
         }
         used_bels.insert(dedicated);
         ci->attrs[id_BEL] = std::string(ctx->nameOfBel(dedicated));
-        log_info("    Constrained BUFIO '%s' to bel '%s' (dedicated site of the pad at %s)\n", ctx->nameOf(ci),
-                 ctx->nameOfBel(dedicated), ctx->nameOfBel(pad_bel));
+        log_info("    Constrained %s '%s' to bel '%s' (dedicated site of the pad at %s)\n",
+                 ci->type.c_str(ctx), ctx->nameOf(ci), ctx->nameOfBel(dedicated), ctx->nameOfBel(pad_bel));
     }
 }
 


### PR DESCRIPTION
`constrain_bufios()` (added in #168) tests `ci->type == id_BUFIO_BUFIO`, so a
BUFR never enters it. A pad-fed BUFR carries the identical constraint, for the
identical reason given in that function's own comment: its `I` pin is reached
only by the `I2IOCLK` leg of its own clock-capable pad, so exactly one
`BUFR_BUFR` bel of the tile is routable from a given pad — and nothing tells
the placer which.

**xc7a35t hides this.** Few sites, the placer guesses right, and every BUFR
probe in #149 passed. On an **xc7a200tfbg484-2** with the 200 MHz differential
pad at `R4` (`IO_L13P_T2_MRCC_34`), it fails in the router — the pre-#168 BUFIO
symptom, one buffer type over:

```
ERROR: Failed to route arc 0 of net 'clk_ibuf'
```

Three placer seeds, three failures.

Everything after the type test already reads `ci->type`, so widening the
predicate is the entire change. The two log messages become type-generic so
they name whichever buffer they constrained. With the patch:

```
Info:     Constrained BUFR_BUFR 'bufr_i' to bel 'BUFR_X1Y8/BUFR'
            (dedicated site of the pad at IOB_X1Y124/IOB33M/INBUF_EN)
```

## Scope

This fixes the arc **into** the buffer. The arc **out of** it is a separate
problem — a BUFR drives one clock region and nothing constrains the flops it
clocks to live there — so on the same design this patch alone still ends at:

```
ERROR: Failed to route arc 0 of net 'clk_bufr',
       from SITEWIRE/BUFR_X1Y8/O to SITEWIRE/SLICE_X42Y222/CLKINV_OUT
```

That half is the companion PR. The two are independent: this one is worth
having on its own, and the other one also improves BUFIO.

## Testing

Built on `a0410d5` (Apple clang, `-DUSE_OPENMP=OFF`). With both patches applied,
the probe from #149 places, routes, emits
`HCLK_L.ENABLE_BUFFER.HCLK_CK_BUFRCLK2`, assembles to a bitstream and **blinks
an LED on hardware** — see
https://github.com/openXC7/nextpnr-xilinx/issues/149#issuecomment-5494347759 for
the single-bit A/B that came out of it.

Refs #149.
