### PR TITLE
xilinx: keep a regional buffer's sinks inside its clock region

### DIFF
--- a/xilinx/pack.h
+++ b/xilinx/pack.h
@@ -251,6 +251,7 @@ struct XC7Packer : public XilinxPacker
     // Bind every pad-fed BUFIO to the one site its pad can reach; run from
     // pack_gbs(), after pack_io() has placed the pads.
     void constrain_bufios();
+    void constrain_regional_clock_sinks(CellInfo *buf);
     void pack_clocking();
 
     // CFG

--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -373,6 +373,100 @@ void XC7Packer::pack_gbs()
 // try_preplace() runs for a BUFG -- and constrain the cell to it.  A table of
 // pad->site pairs would answer the same question for artix7 today and be wrong
 // for the next family; the graph is per-part data and already knows.
+// Binding the buffer to the right site fixes the arc into it.  The arc out of
+// it is a separate problem: a BUFR drives one clock region, and nothing tells
+// the placer that the flops it clocks have to live there.  The placer does not
+// cost global nets, so the flops follow whatever data pin they touch and the
+// router then fails on the clock:
+//
+//   Failed to route arc 0 of net 'clk_bufr',
+//   from SITEWIRE/BUFR_X1Y8/O to SITEWIRE/SLICE_X42Y222/CLKINV_OUT
+//
+// (xc7a200tfbg484-2, pad at R4 in bank 34 -- the flops had gone to the LED in
+// bank 16, half a die away.)
+//
+// Ask the graph where the clock actually arrives, exactly as the site search
+// above does, and hand the placer that rectangle.  Deriving it from geometry
+// would mean encoding how tall a clock region is per family; the routing graph
+// is per-part data and already knows.
+void XC7Packer::constrain_regional_clock_sinks(CellInfo *buf)
+{
+    NetInfo *clk = get_net_or_empty(buf, id_O);
+    if (clk == nullptr || clk->users.empty())
+        return;
+    if (!buf->attrs.count(id_BEL))
+        return;
+    BelId buf_bel = ctx->getBelByName(ctx->id(buf->attrs.at(id_BEL).as_string()));
+    if (buf_bel == BelId())
+        return;
+
+    WireId src = ctx->getBelPinWire(buf_bel, id_O);
+    if (src == WireId())
+        return;
+
+    // Same effort cap and the same layer-by-layer walk as
+    // find_bel_with_short_route(); here we want every bel the clock reaches
+    // rather than the nearest one, so the walk runs to exhaustion.
+    const size_t max_visit = 1000000;
+    std::unordered_set<WireId> visited{src};
+    std::vector<WireId> frontier{src};
+    bool any = false;
+    int x0 = 0, y0 = 0, x1 = 0, y1 = 0;
+    while (!frontier.empty() && visited.size() < max_visit) {
+        for (WireId w : frontier) {
+            for (auto bp : ctx->getWireBelPins(w)) {
+                // Only where the clock can actually clock something.  Counting
+                // every bel pin the walk touches returns the whole die: a wire
+                // brushing some bel's data input says nothing about the clock
+                // reaching its CLK, and the resulting rectangle was x8..264
+                // y26..234 -- no constraint at all.
+                if (bp.pin != id_CLK)
+                    continue;
+                Loc l = ctx->getBelLocation(bp.bel);
+                if (!any) {
+                    x0 = x1 = l.x;
+                    y0 = y1 = l.y;
+                    any = true;
+                } else {
+                    x0 = std::min(x0, l.x);
+                    x1 = std::max(x1, l.x);
+                    y0 = std::min(y0, l.y);
+                    y1 = std::max(y1, l.y);
+                }
+            }
+        }
+        std::vector<WireId> next_frontier;
+        for (WireId w : frontier)
+            for (auto pip : ctx->getPipsDownhill(w)) {
+                WireId dst = ctx->getPipDstWire(pip);
+                if (visited.count(dst))
+                    continue;
+                visited.insert(dst);
+                next_frontier.push_back(dst);
+            }
+        frontier.swap(next_frontier);
+    }
+    if (!any)
+        return;
+
+    IdString rname = ctx->id("clkregion_" + buf->name.str(ctx));
+    ctx->createRectangularRegion(rname, x0, y0, x1, y1);
+    int n = 0;
+    for (auto &usr : clk->users) {
+        // A cell already inside a placement cluster is positioned relative to
+        // its root, so constrain the root and let the cluster follow it.
+        CellInfo *tgt = usr.cell;
+        while (tgt->constr_parent != nullptr)
+            tgt = tgt->constr_parent;
+        if (tgt->region == nullptr) {
+            ctx->constrainCellToRegion(tgt->name, rname);
+            ++n;
+        }
+    }
+    log_info("    Constrained %d sink(s) of %s '%s' to its clock region x%d..%d y%d..%d\n", n,
+             buf->type.c_str(ctx), ctx->nameOf(buf), x0, x1, y0, y1);
+}
+
 void XC7Packer::constrain_bufios()
 {
     for (auto cell : sorted(ctx->cells)) {
@@ -431,6 +525,7 @@ void XC7Packer::constrain_bufios()
         }
         used_bels.insert(dedicated);
         ci->attrs[id_BEL] = std::string(ctx->nameOfBel(dedicated));
+        constrain_regional_clock_sinks(ci);
         log_info("    Constrained BUFIO '%s' to bel '%s' (dedicated site of the pad at %s)\n", ctx->nameOf(ci),
                  ctx->nameOfBel(dedicated), ctx->nameOfBel(pad_bel));
     }


### PR DESCRIPTION
Companion to #170. That one fixes the arc **into** a regional buffer; this one
fixes the arc **out of** it.

A BUFIO/BUFR drives one clock region, and nothing tells the placer that the
cells it clocks have to live there. The placer does not cost global nets, so
those cells follow whatever data pin they touch. On an xc7a200tfbg484-2 probe
(BUFR from the 200 MHz pad at `R4` in bank 34, counter driving an LED in
bank 16) the flops went to the LED, half a die from the buffer, and the router
died on the clock itself:

```
ERROR: Failed to route arc 0 of net 'clk_bufr',
       from SITEWIRE/BUFR_X1Y8/O to SITEWIRE/SLICE_X42Y222/CLKINV_OUT
```

## Approach

Ask the routing graph where the clock actually arrives — the same move
`find_bel_with_short_route()` makes to learn which site a pad reaches — and
hand the placer that rectangle via `createRectangularRegion` +
`constrainCellToRegion`. A per-family table of clock-region heights would answer
the same question and be wrong for the next family; the graph is per-part data
and already knows.

**One trap worth the comment it got: collect only bel pins named `CLK`.**
Counting every bel pin the walk touches returns `x8..264 y26..234` — the whole
die, i.e. no constraint at all — because a wire brushing some bel's *data* input
says nothing about the clock reaching its `CLK`. With the filter the same probe
gives `x141..263 y103..157`, and it routes.

Sinks already inside a placement cluster are constrained through their root, so
clusters stay intact.

## Scope, honestly

In today's tree the call site is reached only for a BUFIO, and a BUFIO's sinks
are ISERDES/OSERDES in their own I/O column — already in region, so this is
close to a no-op on its own. **The case it actually fixes is a BUFR, which needs
#170 to reach this code at all.** I am sending them separately because they are
independent changes with independent reasoning, not because either is much use
alone; merging #170 first makes this one load-bearing.

No regression: the xc7a35t BUFR probe from #149 still places and routes with
this patch alone (exit 0).

## What the pair unlocks

With both applied, that probe places, routes, emits
`HCLK_L.ENABLE_BUFFER.HCLK_CK_BUFRCLK2`, assembles to a bitstream, and blinks an
LED on an AX7203 — which produced the single-bit A/B confirming one of the four
enable rows from the closed prjxray-db#1:
https://github.com/openXC7/nextpnr-xilinx/issues/149#issuecomment-5494347759

Refs #149.
