### PR TITLE
xc7: fix blanket ppip drop in CLB tiles dropping real CE/A1-D1 routing

### DIFF
--- a/xilinx/python/nextpnr_structs.py
+++ b/xilinx/python/nextpnr_structs.py
@@ -349,7 +349,13 @@ class NextpnrTileType:
 			if p.is_route_thru() and p.src_wire().name().endswith("_CE_INT"):
 				continue
 			if p.is_route_thru() and is_xc7_logic:
-				continue
+				# Drop only 'hint' ppips: LUT-function aggregate wires (e.g. CLBLL_L_A,
+				# CLBLL_L_AMUX). These are routing metadata only, not real connections.
+				# All 'always' ppips (IMUX->A1, BYP->AX, FAN->CE, CLK, SR, LOGIC_OUTS,
+				# etc.) are genuine tile-level connections and must pass through.
+				_last = p.dst_wire().name().rsplit('_', 1)[-1]
+				if _last in ('A', 'B', 'C', 'D', 'AMUX', 'BMUX', 'CMUX', 'DMUX'):
+					continue
 			if p.is_route_thru() and "TFB" in p.dst_wire().name():
 				continue
 			if p.src_wire().name().startswith("CLK_BUFG_R_FBG_OUT"):


### PR DESCRIPTION
nextpnr_structs.py was dropping ALL route-thru pips in CLB tiles (CLBLL_L/R, CLBLM_L/R), including real 'always' connections such as FAN->CE (CEUSEDMUX), IMUX->A1-D1 (LUT inputs), BYP->AX-DX, CLK, SR, and LOGIC_OUTS routing -- not just the 'hint' pseudo-pips (LUT-input aggregate wires like CLBLL_L_A/AMUX) that are safe to drop as routing metadata only.

Any design using CE != VCC, or needing real A1-D1 LUT input connections, silently fails to route in affected CLB tiles.

Fix: distinguish 'hint' ppips from real 'always' ppips by destination wire name suffix. Verified against prjxray-db's spartan7 ppips_clbll_l/r and ppips_clblm_l/r.db: every 'hint' entry's destination wire ends in exactly one of A/B/C/D/AMUX/BMUX/CMUX/DMUX, and no 'always' entry does -- zero false positives/negatives across all four CLB ppip files.

Verified on real hardware target xc7s25csga324-1: a 241-FF/649-LUT design (16450 UART core, heavy CE usage) that previously stalled during routing (Stage-1 CE-only fix reached ~100 nets before failing on A1 destinations) now routes completely with 0 errors, timing closing at 98.56 MHz against a 12 MHz target.