### PR TITLE
xc7: treat a present-but-undefined INIT param the same as absent for FDSE/FDPE

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -756,7 +756,19 @@ struct FasmBackend
                 // (PCS/PMA gmii_rst_sync, GT TX startup) at configuration.
                 int def_init = (type == "FDSE" || type == "FDSE_1" ||
                                 type == "FDPE" || type == "FDPE_1") ? 1 : 0;
-                zinit = (int_or_default(ff->params, ctx->id("INIT"), def_init) != 1);
+                // int_or_default only falls back to def_init when INIT is
+                // absent -- but a yosys/async2sync-built netlist (as
+                // opposed to a Vivado-authored one) commonly leaves INIT
+                // *present* with an undefined ('x') value instead of
+                // omitting it, which int_or_default resolves to 0 via
+                // Property::update_intval() (an 'x' bit contributes 0),
+                // silently reproducing the exact bug this comment already
+                // fixed for the absent-parameter case. Treat a present-but-
+                // undefined INIT the same as an absent one.
+                auto init_it = ff->params.find(ctx->id("INIT"));
+                bool init_defined = (init_it != ff->params.end()) && init_it->second.is_fully_def();
+                int init_val = init_defined ? int_or_default(ff->params, ctx->id("INIT"), def_init) : def_init;
+                zinit = (init_val != 1);
                 if (type == "FDRE") {
                     zrst = true;
                     SET_CHECK(negedge_ff, false);


### PR DESCRIPTION
Fixes #178.

## Summary

A register whose RTL sets its power-up/reset value to **1** (synthesizing to `FDSE`/`FDPE`) reads **0** on real hardware, while Vivado correctly reads 1, whenever the netlist reaching this code isn't Vivado-authored (e.g. a plain yosys/`async2sync` flow).

The existing code (comment intact, just extended) already handles the case where Vivado's `write_verilog` omits the `INIT` parameter entirely for a value at its primitive default -- `def_init` correctly recovers `INIT=1` for `FDSE`/`FDPE` in that case. But a yosys-built netlist commonly takes a different path to the same wrong outcome: `INIT` is **present**, just with the literal undefined value `x`, not a concrete `0`/`1`. `int_or_default` only falls back to `def_init` when the key is *missing* -- a present-but-undefined value instead flows through `Property::update_intval()`, where an `x` bit contributes `0`, silently reproducing the exact bug already fixed for the absent case.

## Fix

Use `Property::is_fully_def()` to treat "present but undefined" the same as "absent", falling back to `def_init` in both cases.

## Testing

Verified on real Arty S7-25 hardware (`xc7s25csga324-1`) with a minimal repro (an `FDSE`-mapped register set to 1 on reset, LED-observed): before this fix, the LED read OFF at power-up (matching `INIT=0`, wrong); after, it reads ON (matching `INIT=1`, correct), exactly matching Vivado's behaviour on the identical RTL. Full repro and root-cause trace in #178.

Confirmed this also fixes every previously-affected register in a larger (241-flop) real-world UART design that hit this same bug across several `FDSE`/`FDPE`-mapped signals (a one-shot config-load pulse, an RX line synchronizer, a TX-idle output driver, a status flag) -- zero remaining instances of the broken pattern after this fix.