### PR TITLE
xc7: drop the dead TFB route-thru filter, fix the CLB filter's comment

### DIFF
--- a/xilinx/python/nextpnr_structs.py
+++ b/xilinx/python/nextpnr_structs.py
@@ -348,9 +348,18 @@ class NextpnrTileType:
 			# Exclude certain route-through pips that are broken or unsupported
 			if p.is_route_thru() and p.src_wire().name().endswith("_CE_INT"):
 				continue
+			# is_route_thru() only ever sees pips with is_pseudo=1. In every CLB
+			# tile type (CLBLL_L/R, CLBLM_L/R), across every packaged family,
+			# the only is_pseudo=1 entries are the LUT-input aggregate ("hint")
+			# pass-throughs (e.g. CLBLL_L_A/AMUX) -- these are metadata only,
+			# safe to drop, and are the ones this condition actually excludes
+			# (cross-reference #161 for their eventual proper handling). The
+			# real, always-present connections this filter was once suspected
+			# of also dropping (FAN->CE, IMUX->A1-D1, etc.) are ordinary,
+			# non-pseudo pips -- is_route_thru() is false for them, so they
+			# were never affected by this filter (verified: identical chipdb
+			# output with/without this condition, see nextpnr-xilinx#173).
 			if p.is_route_thru() and is_xc7_logic:
-				continue
-			if p.is_route_thru() and "TFB" in p.dst_wire().name():
 				continue
 			if p.src_wire().name().startswith("CLK_BUFG_R_FBG_OUT"):
 				continue


### PR DESCRIPTION
Follow-up to #173's closure, per @cavearr's handoff at the end of that thread. Two things, both verified directly rather than inherited from #173's framing:

**CLB filter comment**: `is_route_thru()` only ever reflects `is_pseudo=1`from the raw prjxray tile_type JSON. In every CLB tile type (CLBLL_L/R,CLBLM_L/R), across every packaged family, the only `is_pseudo=1` entries are the LUT-input aggregate ("hint") pass-throughs -- the real,always-present connections (FAN->CE, IMUX->A1-D1, etc.) are ordinary, non-pseudo pips, so `is_route_thru()` is false for them and they were never affected by this filter. Confirmed by #173's own A/B (15 chipdb
footprints, byte-identical with/without the patch). Rewrites the comment to state this instead of the original, wrong premise.

**TFB filter**: NOT dead code in the same way -- verified directly by instantiating `NextpnrTileType` for `LIOI3` (via `xilinx_device.import_device()`) with and without the filter: **883 pips with it, 887 without**. The four new pips (`IOI_OLOGIC<n>_T1/TQ -> LIOI_OLOGIC<n>_TFB`) are real, `is_pseudo=1` route-thrus -- an alternate path onto the TFB wire duplicating the OLOGIC's own T-mux selection. But the actual load-bearing OLOGIC-to-ILOGIC tristate feedback path
(`LIOI_OLOGIC<n>_TFB -> ..._TFB_LOCAL -> LIOI_ILOGIC<n>_TFB`) is ordinary `is_pseudo=0` and present regardless of this filter -- so the real DDR/SERDES routing #174 was concerned about was never actually blocked. Removing the filter is a harmless cleanup (pure graph addition -- nothing depends on its absence), **not a verified bugfix**: no OSERDES/ISERDES
bidirectional design has been built to prove the four alternate pips ever matter in practice.

## Testing

Regenerated the `xc7s25csga324-1` chipdb with this change and re-ran the (unrelated) minimal blinky repro through it: routes cleanly, flashed to real hardware, behavior unchanged from before -- no regression.

Per @cavearr's review note on #174 (whether the router could ever pick one of the four new pips as a shortcut for an unrelated net while the OLOGIC is otherwise in use, and whether that contention is modeled or collides silently) -- happy to help however's useful once your bench runs against this branch.

Fixes #174.