### PR TITLE
xc7: Drive constant holdouts from local LUTs and fail if unrouted

### DIFF
--- a/.github/workflows/demos.yml
+++ b/.github/workflows/demos.yml
@@ -106,15 +106,18 @@ jobs:
           '
 
       - name: Build chipdb (${{ matrix.part }})
+        env:
+          PART: ${{ matrix.part }}
         run: |
           nix develop ./toolchain-nix --command bash -euxo pipefail -c '
+            dbpart="${PART%-[0-9]}"
             mkdir -p chipdb
             python3 nextpnr-xilinx/xilinx/python/bbaexport.py \
-              --device ${{ matrix.part }} \
+              --device "$PART" \
               --xray nextpnr-xilinx/xilinx/external/prjxray-db/${{ matrix.family }} \
-              --bba ${{ matrix.part }}.bba
-            build-pr/bbasm -l ${{ matrix.part }}.bba chipdb/${{ matrix.part }}.bin
-            rm -f ${{ matrix.part }}.bba
+              --bba "$dbpart.bba"
+            build-pr/bbasm -l "$dbpart.bba" "chipdb/$dbpart.bin"
+            rm -f "$dbpart.bba"
           '
 
       # FASM-level regression cases (demo-projects/regression/, one
@@ -179,6 +182,7 @@ jobs:
               *) echo "::error::demos gate is not using this PR's nextpnr-xilinx"; exit 1 ;;
             esac
             normhash() { python3 demo-projects/.github/scripts/normbit.py "$1"; }
+            chipdb_before=$(sha256sum chipdb/*.bin)
             for p in $PROJECTS; do
               if ls "demo-projects/$p"/*.bit >/dev/null 2>&1; then
                 cp "demo-projects/$p"/*.bit /tmp/golden-$p
@@ -197,6 +201,11 @@ jobs:
                 echo "no golden for $p, build-only"
               fi
             done
+            chipdb_after=$(sha256sum chipdb/*.bin)
+            if [ "$chipdb_before" != "$chipdb_after" ]; then
+              echo "::error::demos gate did not use this PR's chipdb (chipdb/*.bin changed during the build)"
+              exit 1
+            fi
           EOF
 
       # Built bitstreams are the primary debugging output of this gate;

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -216,6 +216,66 @@ struct Router2
 
     PerWireData &wire_data(WireId w) { return flat_wires[wire_to_idx.at(w)]; }
 
+    // On a re-route, mark already-bound complete arcs as routed with correct
+    // per-wire use counts, so ripup_arc() can release them when contested.
+    void adopt_existing_routing()
+    {
+        for (auto &wd : flat_wires)
+            for (auto &bn : wd.bound_nets)
+                bn.second.first = 0;
+        int adopted = 0;
+        for (NetInfo *net : nets_by_udata) {
+            const bool net_undriven = net->driver.cell == nullptr;
+            if (net_undriven)
+                continue;
+            auto &nd = nets.at(net->udata);
+            for (size_t i = 0; i < net->users.size(); i++) {
+                auto &ad = nd.arcs.at(i);
+                const bool arc_has_no_sink_wire = ad.sink_wire == WireId();
+                if (arc_has_no_sink_wire)
+                    continue;
+                std::vector<int> path;
+                bool complete = false;
+                WireId cursor = ad.sink_wire;
+                while (true) {
+                    int idx = wire_to_idx.at(cursor);
+                    auto &bound_nets = flat_wires.at(idx).bound_nets;
+                    auto it = bound_nets.find(net->udata);
+                    const bool wire_not_bound_to_net = it == bound_nets.end();
+                    if (wire_not_bound_to_net)
+                        break;
+                    path.push_back(idx);
+                    const bool reached_source = cursor == nd.src_wire;
+                    if (reached_source) {
+                        complete = true;
+                        break;
+                    }
+                    PipId pip = it->second.second;
+                    const bool no_uphill_pip_recorded = pip == PipId();
+                    if (no_uphill_pip_recorded)
+                        break;
+                    cursor = ctx->getPipSrcWire(pip);
+                }
+                if (!complete)
+                    continue;
+                for (int idx : path)
+                    flat_wires.at(idx).bound_nets.at(net->udata).first++;
+                ad.routed = true;
+                adopted++;
+            }
+        }
+        for (auto &wd : flat_wires) {
+            for (auto &bn : wd.bound_nets) {
+                const bool binding_used_by_no_arc = bn.second.first == 0;
+                if (binding_used_by_no_arc)
+                    bn.second.first = 1;
+            }
+        }
+        const bool any_adopted = adopted > 0;
+        if (any_adopted)
+            log_info("Adopted %d pre-routed arc(s)\n", adopted);
+    }
+
     void setup_wires()
     {
         // Set up per-wire structures, so that MT parts don't have to do any memory allocation
@@ -1431,6 +1491,7 @@ struct Router2
         auto rstart = std::chrono::high_resolution_clock::now();
         setup_nets();
         setup_wires();
+        adopt_existing_routing();
         find_all_reserved_wires();
         partition_nets();
         curr_cong_weight = cfg.init_curr_cong_weight;

--- a/common/router2.cc
+++ b/common/router2.cc
@@ -1236,16 +1236,21 @@ struct Router2
     {
         bool success = true;
         std::vector<WireId> net_wires;
-        for (auto net : nets_by_udata) {
+        auto routable = [&](NetInfo *net) {
 #ifdef ARCH_ECP5
             if (net->is_global)
-                continue;
+                return false;
 #endif
             // Constant nets are deliberately left unrouted by router2 (routed by the
             // final router1 route_const_arc pass), so there is nothing to bind here.
-            if (net->name == ctx->id("$PACKER_GND_NET") || net->name == ctx->id("$PACKER_VCC_NET"))
+            return net->name != ctx->id("$PACKER_GND_NET") && net->name != ctx->id("$PACKER_VCC_NET");
+        };
+        // Unbind every net's old routing first: on a re-route, binding net by
+        // net would trip checkWireAvail on wires another net still holds.
+        for (auto net : nets_by_udata) {
+            const bool net_is_routable = routable(net);
+            if (!net_is_routable)
                 continue;
-            // Ripup wires and pips used by the net in nextpnr's structures
             net_wires.clear();
             for (auto &w : net->wires) {
                 if (w.second.strength <= STRENGTH_STRONG)
@@ -1253,6 +1258,11 @@ struct Router2
             }
             for (auto w : net_wires)
                 ctx->unbindWire(w);
+        }
+        for (auto net : nets_by_udata) {
+            const bool net_is_routable = routable(net);
+            if (!net_is_routable)
+                continue;
             // Bind the arcs using the routes we have discovered
             for (size_t i = 0; i < net->users.size(); i++) {
                 if (!bind_and_check(net, i)) {

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -909,8 +909,9 @@ bool Arch::place()
     return true;
 }
 
-void Arch::routeVcc()
+std::vector<Arch::ConstHoldout> Arch::routeVcc()
 {
+    std::vector<ConstHoldout> holdouts;
     // Route BOTH constant pseudo-nets (Vcc and Gnd) through their real bridge
     // pips before the main router, so fasm.cc emits the const distribution and
     // silicon actually gets the constants.  (Originally Vcc-only + router1-only;
@@ -925,9 +926,8 @@ void Arch::routeVcc()
         { id("$PACKER_VCC_NET"), ID_PSEUDO_VCC },
         { id("$PACKER_GND_NET"), ID_PSEUDO_GND },
     };
-    // Record GND sinks the backbone fill can't reach, so a second pass can drive
-    // them from a local LUT1(INIT=0) instead (see pack_carry_xc7.cc).  One line
-    // per holdout: "<cell> <port>" (e.g. "mem_addr_reg_13__i_2 DI0").
+    // Unreached sinks are returned to the caller; NEXTPNR_GND_HOLDOUT_FILE also
+    // dumps the GND ones as "<cell> <port>" lines.
     std::ofstream holdout_out;
     if (const char *hf = getenv("NEXTPNR_GND_HOLDOUT_FILE"))
         holdout_out.open(hf);
@@ -980,11 +980,9 @@ void Arch::routeVcc()
                 max_iter_seen = iter;
             if (dest == WireId()) {
                 ++unrouted;
-                if (getenv("NEXTPNR_LOG_CONST_HOLDOUTS"))
-                    log_info("    %s HOLDOUT: %s.%s (bel %s)\n", cn.first.c_str(this),
-                             usr.cell->name.c_str(this), usr.port.c_str(this),
-                             nameOfBel(usr.cell->bel));
-                // GND holdouts only: a local LUT1(INIT=0) can replace these.
+                log_info("    %s HOLDOUT: %s.%s (bel %s, wire %s)\n", cn.first.c_str(this), usr.cell->name.c_str(this),
+                         usr.port.c_str(this), nameOfBel(usr.cell->bel), nameOfWire(sink));
+                holdouts.push_back(ConstHoldout{net, usr.cell, usr.port, pseudo_intent == ID_PSEUDO_VCC});
                 if (holdout_out.is_open() && cn.second == ID_PSEUDO_GND)
                     holdout_out << usr.cell->name.c_str(this) << " "
                                 << usr.port.c_str(this) << "\n";
@@ -999,10 +997,10 @@ void Arch::routeVcc()
                     bindPip(uh, net, STRENGTH_STRONG);
             }
         }
-        log_info("    %s: %d/%d sinks bridged (%d left to main router; max BFS %d)\n",
-                 cn.first.c_str(this), int(net->users.size()) - unrouted, int(net->users.size()),
-                 unrouted, max_iter_seen);
+        log_info("    %s: %d/%d sinks bridged (%d holdouts; max BFS %d)\n", cn.first.c_str(this),
+                 int(net->users.size()) - unrouted, int(net->users.size()), unrouted, max_iter_seen);
     }
+    return holdouts;
 }
 
 // BODGE: template a GT-clock -> BUFG route from the known-good Vivado path.

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -941,6 +941,7 @@ std::vector<Arch::ConstHoldout> Arch::routeVcc()
         if (src != WireId())
             bindWire(src, net, STRENGTH_STRONG);
         int unrouted = 0, max_iter_seen = 0;
+        std::vector<ConstHoldout> net_holdouts;
         for (auto &usr : net->users) {
             std::queue<WireId> visit;
             std::unordered_map<WireId, PipId> backtrace;
@@ -982,10 +983,7 @@ std::vector<Arch::ConstHoldout> Arch::routeVcc()
                 ++unrouted;
                 log_info("    %s HOLDOUT: %s.%s (bel %s, wire %s)\n", cn.first.c_str(this), usr.cell->name.c_str(this),
                          usr.port.c_str(this), nameOfBel(usr.cell->bel), nameOfWire(sink));
-                holdouts.push_back(ConstHoldout{net, usr.cell, usr.port, pseudo_intent == ID_PSEUDO_VCC});
-                if (holdout_out.is_open() && cn.second == ID_PSEUDO_GND)
-                    holdout_out << usr.cell->name.c_str(this) << " "
-                                << usr.port.c_str(this) << "\n";
+                net_holdouts.push_back(ConstHoldout{net, usr.cell, usr.port, pseudo_intent == ID_PSEUDO_VCC});
                 continue;
             }
             while (backtrace.count(dest)) {
@@ -996,6 +994,25 @@ std::vector<Arch::ConstHoldout> Arch::routeVcc()
                 if (getBoundPipNet(uh) == nullptr)
                     bindPip(uh, net, STRENGTH_STRONG);
             }
+        }
+        // Users sharing a site wire (SLICEM WA1..6 and A1..6) are reached once
+        // the per-user BFS binds that wire for any of them.
+        for (auto &h : net_holdouts) {
+            PortRef pr;
+            pr.cell = h.cell;
+            pr.port = h.port;
+            WireId sink = getCtx()->getNetinfoSinkWire(net, pr);
+            const bool wire_bound_for_later_user = getBoundWireNet(sink) == net;
+            if (wire_bound_for_later_user) {
+                --unrouted;
+                log_info("    %s HOLDOUT %s.%s reached after all: wire %s bound for a later user\n",
+                         cn.first.c_str(this), h.cell->name.c_str(this), h.port.c_str(this), nameOfWire(sink));
+                continue;
+            }
+            holdouts.push_back(h);
+            const bool dump_gnd_holdout = holdout_out.is_open() && cn.second == ID_PSEUDO_GND;
+            if (dump_gnd_holdout)
+                holdout_out << h.cell->name.c_str(this) << " " << h.port.c_str(this) << "\n";
         }
         log_info("    %s: %d/%d sinks bridged (%d holdouts; max BFS %d)\n", cn.first.c_str(this),
                  int(net->users.size()) - unrouted, int(net->users.size()), unrouted, max_iter_seen);

--- a/xilinx/arch.cc
+++ b/xilinx/arch.cc
@@ -2132,27 +2132,31 @@ bool Arch::route()
     }
     findSourceSinkLocations();
 
-    bool result;
-    if (router == "router1") {
-        result = router1(getCtx(), Router1Cfg(getCtx()));
-    } else if (router == "router2") {
-        auto cfg = Router2Cfg(getCtx());
-        cfg.bb_margin_x = 4;
-        cfg.bb_margin_y = 4;
-        cfg.backwards_max_iter = 200;
-        cfg.perf_profile = true;
-        router2(getCtx(), cfg);
-        result = true;
-    } else {
-        log_error("Xilinx architecture does not support router '%s'\n", router.c_str());
-    }
+    bool result = true;
+    auto run_router = [&]() {
+        if (router == "router1") {
+            result = router1(getCtx(), Router1Cfg(getCtx()));
+        } else if (router == "router2") {
+            auto cfg = Router2Cfg(getCtx());
+            cfg.bb_margin_x = 4;
+            cfg.bb_margin_y = 4;
+            cfg.backwards_max_iter = 200;
+            cfg.perf_profile = true;
+            router2(getCtx(), cfg);
+            result = true;
+        } else {
+            log_error("Xilinx architecture does not support router '%s'\n", router.c_str());
+        }
+    };
+    run_router();
     // routeVcc as a FILL pass: run AFTER the main router so signal nets claim
     // their wires first, then bridge the constant (pwr/gnd) nets through whatever
     // real pips remain free (the BFS already gates on checkWireAvail/checkPipAvail).
     // Pre-router binding over-constrained routing and made router2 fail to route
     // address-path FF arcs (e.g. mem_addr O5->AFFMUX), so const-routed builds
     // exited 255; as a post-router fill it only consumes leftover resources.
-    routeVcc();
+    // routeConstants() drives what the fill misses from local LUTs and re-routes.
+    routeConstants(run_router);
     fixupRouting();
     // router1 runs its own final timing analysis; the router2 flow
     // historically ended without one, so the last "Max frequency" lines the

--- a/xilinx/arch.h
+++ b/xilinx/arch.h
@@ -25,6 +25,7 @@
 
 #include <boost/iostreams/device/mapped_file.hpp>
 
+#include <functional>
 #include <iostream>
 
 NEXTPNR_NAMESPACE_BEGIN
@@ -1672,6 +1673,10 @@ struct Arch : BaseCtx
         bool value; // constant the pin requires
     };
     std::vector<ConstHoldout> routeVcc();
+    bool allow_const_holdouts = false;
+    void routeConstants(std::function<void()> reroute);
+    int insertConstDrivers(const std::vector<ConstHoldout> &holdouts, std::vector<ConstHoldout> &unplaced);
+    void ripupConstNets();
     void routeClock();
     void applyFixedRoutes(const std::string &filename);
     void writeFixedRoutes(const std::string &filename) const;

--- a/xilinx/arch.h
+++ b/xilinx/arch.h
@@ -1663,7 +1663,15 @@ struct Arch : BaseCtx
     void fixupPlacement();
     void fixupRouting();
 
-    void routeVcc();
+    // A constant-net sink the backbone fill pass (routeVcc) could not reach.
+    struct ConstHoldout
+    {
+        NetInfo *net; // $PACKER_GND_NET or $PACKER_VCC_NET
+        CellInfo *cell;
+        IdString port;
+        bool value; // constant the pin requires
+    };
+    std::vector<ConstHoldout> routeVcc();
     void routeClock();
     void applyFixedRoutes(const std::string &filename);
     void writeFixedRoutes(const std::string &filename) const;

--- a/xilinx/main.cc
+++ b/xilinx/main.cc
@@ -55,8 +55,9 @@ po::options_description UspCommandHandler::getArchOptions()
     specific.add_options()("write-fixed-routes", po::value<std::string>(),
                            "after routing, dump fabric routing in --fixed-routes format");
     specific.add_options()("allow-const-holdouts",
-                           "only warn when a constant (GND/VCC) sink cannot be routed; the pin's silicon "
-                           "value is then undefined (default: error)");
+                           "only warn when a constant (GND/VCC) sink cannot be driven; the pin's silicon "
+                           "value is then undefined (default: error).  Does not cover a constant driver "
+                           "LUT whose net the router itself fails to route");
 
     return specific;
 }

--- a/xilinx/main.cc
+++ b/xilinx/main.cc
@@ -54,6 +54,9 @@ po::options_description UspCommandHandler::getArchOptions()
                            "frozen hard-macro routing to LOCK before routing (net + src->dst pips)");
     specific.add_options()("write-fixed-routes", po::value<std::string>(),
                            "after routing, dump fabric routing in --fixed-routes format");
+    specific.add_options()("allow-const-holdouts",
+                           "only warn when a constant (GND/VCC) sink cannot be routed; the pin's silicon "
+                           "value is then undefined (default: error)");
 
     return specific;
 }
@@ -91,6 +94,9 @@ void UspCommandHandler::customAfterLoad(Context *ctx)
     }
     if (vm.count("fixed-routes"))
         ctx->settings[ctx->id("fixed-routes")] = vm["fixed-routes"].as<std::string>();
+    const bool allow_const_holdouts_given = vm.count("allow-const-holdouts") != 0;
+    if (allow_const_holdouts_given)
+        ctx->allow_const_holdouts = true;
 }
 
 int main(int argc, char *argv[])

--- a/xilinx/route_const.cc
+++ b/xilinx/route_const.cc
@@ -324,8 +324,10 @@ void Arch::routeConstants(std::function<void()> reroute)
     const bool no_drivers = getenv("NEXTPNR_NO_CONST_LUT_DRIVERS") != nullptr;
 
     // Fatal by default: an unrouted constant sink reads as 1 in silicon.
-    auto report = [&](const std::vector<ConstHoldout> &left, const char *why) {
-        for (auto &h : left) {
+    auto report = [&](const std::vector<std::pair<ConstHoldout, const char *>> &left) {
+        for (auto &e : left) {
+            const ConstHoldout &h = e.first;
+            const char *why = e.second;
             PortRef pr;
             pr.cell = h.cell;
             pr.port = h.port;
@@ -349,7 +351,12 @@ void Arch::routeConstants(std::function<void()> reroute)
     };
 
     std::set<std::pair<IdString, IdString>> given_up; // (cell, port) already reported
-    std::vector<ConstHoldout> given_up_list;
+    std::vector<std::pair<ConstHoldout, const char *>> given_up_list;
+    const char *why_unplaced = no_drivers ? "constant LUT drivers disabled" : "no route or no free LUT bel";
+    auto give_up = [&](const ConstHoldout &h, const char *why) {
+        given_up.insert(std::make_pair(h.cell->name, h.port));
+        given_up_list.push_back(std::make_pair(h, why));
+    };
     int drivers = 0, dont_care = 0, passes = 0;
     for (int pass = 0;; pass++) {
         auto holdouts = routeVcc();
@@ -367,29 +374,41 @@ void Arch::routeConstants(std::function<void()> reroute)
             const bool already_given_up = given_up.count(std::make_pair(h.cell->name, h.port)) != 0;
             if (already_given_up)
                 continue;
+            // A sink wire no pip drives (DSP48E1 INMODE/ALUMODE/OPMODE, #159) is
+            // unreachable for any net, so report it rather than add a driver.
+            PortRef pr;
+            pr.cell = h.cell;
+            pr.port = h.port;
+            WireId sink = ctx->getNetinfoSinkWire(h.net, pr);
+            auto uphill = getPipsUphill(sink);
+            const bool sink_has_uphill_pip = uphill.begin() != uphill.end();
+            if (!sink_has_uphill_pip) {
+                give_up(h, "no pip drives the sink wire");
+                continue;
+            }
             real.push_back(h);
         }
         const bool nothing_left = real.empty();
         if (nothing_left)
             break;
         if (no_drivers) {
-            given_up_list.insert(given_up_list.end(), real.begin(), real.end());
+            for (auto &h : real)
+                give_up(h, why_unplaced);
             break;
         }
         const bool out_of_passes = pass >= max_passes;
         if (out_of_passes) {
             log_warning("constant holdouts remain after %d re-route pass(es)\n", pass);
-            given_up_list.insert(given_up_list.end(), real.begin(), real.end());
+            for (auto &h : real)
+                give_up(h, why_unplaced);
             break;
         }
         log_info("Constant fill left %d sink(s) unreached; driving them from local constant LUTs (pass %d)\n",
                  int(real.size()), pass + 1);
         std::vector<ConstHoldout> unplaced;
         drivers += insertConstDrivers(real, unplaced);
-        for (auto &h : unplaced) {
-            given_up.insert(std::make_pair(h.cell->name, h.port));
-            given_up_list.push_back(h);
-        }
+        for (auto &h : unplaced)
+            give_up(h, why_unplaced);
         const bool nothing_placed = unplaced.size() == real.size();
         if (nothing_placed)
             break; // nothing changed, re-routing would not help
@@ -406,7 +425,7 @@ void Arch::routeConstants(std::function<void()> reroute)
                  drivers, passes, dont_care);
     const bool have_leftovers = !given_up_list.empty();
     if (have_leftovers)
-        report(given_up_list, no_drivers ? "constant LUT drivers disabled" : "no route or no free LUT bel");
+        report(given_up_list);
 }
 
 NEXTPNR_NAMESPACE_END

--- a/xilinx/route_const.cc
+++ b/xilinx/route_const.cc
@@ -1,0 +1,359 @@
+/*
+ *  nextpnr -- Next Generation Place and Route
+ *
+ *  Copyright (C) 2026  The openXC7 contributors
+ *
+ *  Permission to use, copy, modify, and/or distribute this software for any
+ *  purpose with or without fee is hereby granted, provided that the above
+ *  copyright notice and this permission notice appear in all copies.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ *  WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ *  MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ *  ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ *  WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ *  ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ *  OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ *
+ */
+
+// Constant-net holdouts: sinks routeVcc() cannot reach are driven from a local
+// constant LUT and the design is re-routed; leftovers are fatal unless allowed.
+
+#include <map>
+#include <set>
+#include "cells.h"
+#include "design_utils.h"
+#include "log.h"
+#include "nextpnr.h"
+#include "util.h"
+
+NEXTPNR_NAMESPACE_BEGIN
+
+namespace {
+
+// How far (in tiles) to look for a free LUT bel around a holdout's tile.
+const int const_lut_search_radius = 24;
+// Re-route passes before the remaining holdouts are reported.
+const int const_holdout_max_passes = 6;
+// LUTs to follow when proving a net constant.
+const int const_net_lut_depth = 4;
+
+// Value of a provably constant net (through constant-output LUTs): 0, 1, or -1.
+int const_net_value(Context *ctx, NetInfo *net, int depth = 0)
+{
+    const bool no_net = net == nullptr;
+    if (no_net)
+        return -1;
+    const bool is_gnd_net = net->name == ctx->id("$PACKER_GND_NET");
+    if (is_gnd_net)
+        return 0;
+    const bool is_vcc_net = net->name == ctx->id("$PACKER_VCC_NET");
+    if (is_vcc_net)
+        return 1;
+    const bool too_deep = depth > const_net_lut_depth;
+    if (too_deep)
+        return -1;
+    CellInfo *drv = net->driver.cell;
+    const bool driven_by_lut_o6 = drv != nullptr && drv->type == id_SLICE_LUTX && net->driver.port == id_O6;
+    if (!driven_by_lut_o6)
+        return -1;
+    auto init_it = drv->params.find(ctx->id("INIT"));
+    const bool has_bit_init = init_it != drv->params.end() && !init_it->second.is_string;
+    if (!has_bit_init)
+        return -1;
+    const std::string &init = init_it->second.str;
+    const IdString a_ports[6] = {id_A1, id_A2, id_A3, id_A4, id_A5, id_A6};
+    // Input count from the recorded LUTk type, else the highest connected pin
+    // (INIT is zero-padded, so its size cannot be used).
+    int k = 0;
+    std::string orig = str_or_default(drv->attrs, ctx->id("X_ORIG_TYPE"), "");
+    const bool orig_is_lutk = orig.size() == 4 && orig.compare(0, 3, "LUT") == 0 && orig[3] >= '1' && orig[3] <= '6';
+    if (orig_is_lutk) {
+        k = orig[3] - '0';
+    } else {
+        for (int i = 0; i < 6; i++) {
+            const bool input_connected = get_net_or_empty(drv, a_ports[i]) != nullptr;
+            if (input_connected)
+                k = i + 1;
+        }
+    }
+    int width = 1 << k;
+    const bool init_too_short = int(init.size()) < width;
+    if (init_too_short)
+        return -1;
+    int fixed[6];
+    for (int i = 0; i < k; i++) {
+        NetInfo *in = get_net_or_empty(drv, a_ports[i]);
+        const bool input_unconnected = in == nullptr;
+        if (input_unconnected) {
+            fixed[i] = -1; // INIT must not depend on it
+            continue;
+        }
+        fixed[i] = const_net_value(ctx, in, depth + 1);
+        const bool input_not_constant = fixed[i] < 0;
+        if (input_not_constant)
+            return -1;
+    }
+    int result = -1;
+    for (int idx = 0; idx < width; idx++) {
+        bool reachable = true;
+        for (int i = 0; i < k; i++) {
+            const bool row_contradicts_fixed_input = fixed[i] >= 0 && ((idx >> i) & 1) != fixed[i];
+            if (row_contradicts_fixed_input)
+                reachable = false;
+        }
+        if (!reachable)
+            continue;
+        int bit = (init.at(idx) == Property::S1) ? 1 : 0;
+        const bool first_reachable_row = result < 0;
+        const bool row_disagrees = result != bit;
+        if (first_reachable_row)
+            result = bit;
+        else if (row_disagrees)
+            return -1;
+    }
+    return result;
+}
+
+// A CARRY4 DI[i] is a don't-care when S[i] is constant 1 (the DI mux is never selected).
+bool holdout_is_dont_care(Context *ctx, const Arch::ConstHoldout &h)
+{
+    const bool is_carry4 = h.cell->type == id_CARRY4;
+    if (!is_carry4)
+        return false;
+    std::string p = h.port.str(ctx);
+    const bool is_di_pin = p.size() == 3 && p.compare(0, 2, "DI") == 0;
+    if (!is_di_pin)
+        return false;
+    NetInfo *s = get_net_or_empty(h.cell, ctx->id(std::string("S") + p[2]));
+    return const_net_value(ctx, s) == 1;
+}
+
+} // namespace
+
+// Unbind everything the constant nets own ahead of a re-route.
+void Arch::ripupConstNets()
+{
+    for (const char *name : {"$PACKER_GND_NET", "$PACKER_VCC_NET"}) {
+        auto it = nets.find(id(name));
+        const bool net_absent = it == nets.end();
+        if (net_absent)
+            continue;
+        std::vector<WireId> wires;
+        for (auto &w : it->second->wires)
+            wires.push_back(w.first);
+        for (auto w : wires)
+            unbindWire(w);
+    }
+}
+
+// Drive the holdouts from input-less constant LUTs, one per (constant, sink
+// tile); returns the LUT count, with unplaceable holdouts in unplaced.
+int Arch::insertConstDrivers(const std::vector<ConstHoldout> &holdouts, std::vector<ConstHoldout> &unplaced)
+{
+    Context *ctx = getCtx();
+    const int max_radius = const_lut_search_radius;
+    auto tile_is_logic = [&](int tile) {
+        IdString t(chip_info->tile_types[chip_info->tile_insts[tile].type].type);
+        return t == id_CLBLL_L || t == id_CLBLL_R || t == id_CLBLM_L || t == id_CLBLM_R || t == id_CLEL_L ||
+               t == id_CLEL_R || t == id_CLEM || t == id_CLEM_R;
+    };
+    // Ring search outwards from the sink's tile for a free, valid 6LUT+5LUT pair.
+    auto place_lut = [&](CellInfo *lut, Loc origin) -> BelId {
+        for (int r = 0; r <= max_radius; r++) {
+            for (int dy = -r; dy <= r; dy++) {
+                for (int dx = -r; dx <= r; dx++) {
+                    const bool on_ring = std::max(std::abs(dx), std::abs(dy)) == r;
+                    if (!on_ring)
+                        continue;
+                    int x = origin.x + dx, y = origin.y + dy;
+                    const bool on_grid = x >= 0 && y >= 0 && x < getGridDimX() && y < getGridDimY();
+                    if (!on_grid)
+                        continue;
+                    int tile = y * getGridDimX() + x;
+                    const bool is_logic_tile = tile_is_logic(tile);
+                    if (!is_logic_tile)
+                        continue;
+                    for (BelId bel : getBelsByTile(x, y)) {
+                        const bool is_lut_bel = getBelType(bel) == id_SLICE_LUTX;
+                        if (!is_lut_bel)
+                            continue;
+                        Loc l = getBelLocation(bel);
+                        const bool free_6lut = (l.z & 0xF) == BEL_6LUT && checkBelAvail(bel);
+                        if (!free_6lut)
+                            continue;
+                        BelId lut5 = getBelByLocation(Loc(l.x, l.y, (l.z & ~0xF) | BEL_5LUT));
+                        const bool free_5lut = lut5 == BelId() || checkBelAvail(lut5);
+                        if (!free_5lut)
+                            continue;
+                        bindBel(bel, lut, STRENGTH_STRONG);
+                        const bool placement_valid = isBelLocationValid(bel);
+                        if (placement_valid)
+                            return bel;
+                        unbindBel(bel);
+                    }
+                }
+            }
+        }
+        return BelId();
+    };
+
+    // One driver LUT per (constant, sink tile); std::map keeps the order deterministic.
+    std::map<std::pair<int, int>, std::vector<ConstHoldout>> groups;
+    for (auto &h : holdouts) {
+        NPNR_ASSERT(h.cell->bel != BelId());
+        groups[std::make_pair(h.value ? 1 : 0, h.cell->bel.tile)].push_back(h);
+    }
+
+    int added = 0, seq = 0;
+    for (auto &g : groups) {
+        bool value = g.first.first != 0;
+        const char *base = value ? "$PACKER_VCC_NET" : "$PACKER_GND_NET";
+        IdString cname, nname;
+        while (true) {
+            cname = id(stringf("%s$HOLDOUT$LUT$%d", base, seq));
+            nname = id(stringf("%s$holdout$%d", base, seq));
+            seq++;
+            const bool name_taken = cells.count(cname) || nets.count(nname);
+            if (!name_taken)
+                break;
+        }
+
+        std::unique_ptr<CellInfo> lut = create_cell(ctx, id_SLICE_LUTX, cname);
+        // A LUT1 with no input: fasm.cc then writes INIT[0] to every truth-table bit.
+        lut->attrs[id("X_ORIG_TYPE")] = std::string("LUT1");
+        lut->attrs[id("X_ORIG_PORT_O6")] = std::string("O");
+        lut->params[id("INIT")] = Property(value ? 3 : 0, 2);
+        std::unique_ptr<NetInfo> net{new NetInfo};
+        net->name = nname;
+        connect_port(ctx, net.get(), lut.get(), id_O6);
+        CellInfo *lut_ptr = lut.get();
+        NetInfo *net_ptr = net.get();
+        cells[cname] = std::move(lut);
+        nets[nname] = std::move(net);
+        assignCellInfo(lut_ptr);
+
+        Loc origin = getBelLocation(g.second.front().cell->bel);
+        BelId bel = place_lut(lut_ptr, origin);
+        const bool no_free_lut_bel = bel == BelId();
+        if (no_free_lut_bel) {
+            log_warning("    no free LUT bel within %d tiles of %s for a %s driver\n", max_radius,
+                        nameOfBel(g.second.front().cell->bel), value ? "VCC" : "GND");
+            disconnect_port(ctx, lut_ptr, id_O6);
+            cells.erase(cname);
+            nets.erase(nname);
+            for (auto &h : g.second)
+                unplaced.push_back(h);
+            continue;
+        }
+        for (auto &h : g.second) {
+            disconnect_port(ctx, h.cell, h.port);
+            connect_port(ctx, net_ptr, h.cell, h.port);
+            assignCellInfo(h.cell);
+            log_info("    %s.%s <- %s (bel %s)\n", h.cell->name.c_str(ctx), h.port.c_str(ctx), cname.c_str(ctx),
+                     nameOfBel(bel));
+        }
+        added++;
+    }
+    return added;
+}
+
+void Arch::routeConstants(std::function<void()> reroute)
+{
+    Context *ctx = getCtx();
+    int max_passes = const_holdout_max_passes;
+    const char *passes_env = getenv("NEXTPNR_CONST_HOLDOUT_PASSES");
+    const bool passes_overridden = passes_env != nullptr;
+    if (passes_overridden)
+        max_passes = atoi(passes_env);
+    const bool allow = getenv("NEXTPNR_ALLOW_CONST_HOLDOUTS") != nullptr || allow_const_holdouts;
+    const bool no_drivers = getenv("NEXTPNR_NO_CONST_LUT_DRIVERS") != nullptr;
+
+    // Fatal by default: an unrouted constant sink reads as 1 in silicon.
+    auto report = [&](const std::vector<ConstHoldout> &left, const char *why) {
+        for (auto &h : left) {
+            PortRef pr;
+            pr.cell = h.cell;
+            pr.port = h.port;
+            WireId sink = ctx->getNetinfoSinkWire(h.net, pr);
+            std::string msg = stringf("constant %s not delivered to %s.%s (bel %s, wire %s): %s\n",
+                                      h.value ? "VCC" : "GND", h.cell->name.c_str(ctx), h.port.c_str(ctx),
+                                      nameOfBel(h.cell->bel), sink == WireId() ? "?" : nameOfWire(sink), why);
+            if (allow)
+                log_warning("%s", msg.c_str());
+            else
+                log_nonfatal_error("%s", msg.c_str());
+        }
+        if (allow)
+            log_warning("%d constant sink(s) left unrouted; their silicon value is undefined "
+                        "(--allow-const-holdouts given)\n",
+                        int(left.size()));
+        else
+            log_error("%d constant sink(s) could not be routed; the bitstream would be wrong. "
+                      "Pass --allow-const-holdouts (or set NEXTPNR_ALLOW_CONST_HOLDOUTS=1) to build anyway.\n",
+                      int(left.size()));
+    };
+
+    std::set<std::pair<IdString, IdString>> given_up; // (cell, port) already reported
+    std::vector<ConstHoldout> given_up_list;
+    int drivers = 0, dont_care = 0, passes = 0;
+    for (int pass = 0;; pass++) {
+        auto holdouts = routeVcc();
+        std::vector<ConstHoldout> real;
+        for (auto &h : holdouts) {
+            // Don't-cares first: a pin nothing selects is never an error.
+            const bool is_dont_care = holdout_is_dont_care(ctx, h);
+            if (is_dont_care) {
+                log_info("    %s.%s (bel %s): CARRY4 DI with S=1 never selected, left unrouted\n",
+                         h.cell->name.c_str(ctx), h.port.c_str(ctx), nameOfBel(h.cell->bel));
+                disconnect_port(ctx, h.cell, h.port);
+                dont_care++;
+                continue;
+            }
+            const bool already_given_up = given_up.count(std::make_pair(h.cell->name, h.port)) != 0;
+            if (already_given_up)
+                continue;
+            real.push_back(h);
+        }
+        const bool nothing_left = real.empty();
+        if (nothing_left)
+            break;
+        if (no_drivers) {
+            given_up_list.insert(given_up_list.end(), real.begin(), real.end());
+            break;
+        }
+        const bool out_of_passes = pass >= max_passes;
+        if (out_of_passes) {
+            log_warning("constant holdouts remain after %d re-route pass(es)\n", pass);
+            given_up_list.insert(given_up_list.end(), real.begin(), real.end());
+            break;
+        }
+        log_info("Constant fill left %d sink(s) unreached; driving them from local constant LUTs (pass %d)\n",
+                 int(real.size()), pass + 1);
+        std::vector<ConstHoldout> unplaced;
+        drivers += insertConstDrivers(real, unplaced);
+        for (auto &h : unplaced) {
+            given_up.insert(std::make_pair(h.cell->name, h.port));
+            given_up_list.push_back(h);
+        }
+        const bool nothing_placed = unplaced.size() == real.size();
+        if (nothing_placed)
+            break; // nothing changed, re-routing would not help
+        // Re-route with the constant nets unbound; the next routeVcc fills in again.
+        ripupConstNets();
+        findSourceSinkLocations();
+        reroute();
+        passes++;
+    }
+    const bool anything_changed = drivers > 0 || dont_care > 0;
+    if (anything_changed)
+        log_info("Constant holdouts: %d local constant LUT(s) added, %d re-route pass(es), %d don't-care CARRY4 DI "
+                 "pin(s) left unrouted\n",
+                 drivers, passes, dont_care);
+    const bool have_leftovers = !given_up_list.empty();
+    if (have_leftovers)
+        report(given_up_list, no_drivers ? "constant LUT drivers disabled" : "no route or no free LUT bel");
+}
+
+NEXTPNR_NAMESPACE_END

--- a/xilinx/route_const.cc
+++ b/xilinx/route_const.cc
@@ -20,6 +20,7 @@
 // Constant-net holdouts: sinks routeVcc() cannot reach are driven from a local
 // constant LUT and the design is re-routed; leftovers are fatal unless allowed.
 
+#include <algorithm>
 #include <map>
 #include <set>
 #include "cells.h"
@@ -199,6 +200,33 @@ int Arch::insertConstDrivers(const std::vector<ConstHoldout> &holdouts, std::vec
         return BelId();
     };
 
+    // Every user on a holdout's site wire (e.g. SLICEM WA1..6 and A1..6) must
+    // move with it, since one wire cannot be driven by two nets.
+    std::map<IdString, std::map<WireId, std::vector<PortRef>>> users_by_wire;
+    auto wire_users = [&](NetInfo *net, WireId w) -> const std::vector<PortRef> & {
+        auto &by_wire = users_by_wire[net->name];
+        const bool not_yet_grouped = by_wire.empty();
+        if (not_yet_grouped)
+            for (auto &usr : net->users)
+                by_wire[ctx->getNetinfoSinkWire(net, usr)].push_back(usr);
+        return by_wire.at(w);
+    };
+    auto sink_wire = [&](const ConstHoldout &h) {
+        PortRef pr;
+        pr.cell = h.cell;
+        pr.port = h.port;
+        return ctx->getNetinfoSinkWire(h.net, pr);
+    };
+    auto move_users = [&](NetInfo *from, WireId w, NetInfo *to, const char *how) {
+        std::vector<PortRef> users = wire_users(from, w);
+        for (auto &pr : users) {
+            disconnect_port(ctx, pr.cell, pr.port);
+            connect_port(ctx, to, pr.cell, pr.port);
+            assignCellInfo(pr.cell);
+            log_info("    %s.%s <- %s%s\n", pr.cell->name.c_str(ctx), pr.port.c_str(ctx), to->name.c_str(ctx), how);
+        }
+    };
+
     // One driver LUT per (constant, sink tile); std::map keeps the order deterministic.
     std::map<std::pair<int, int>, std::vector<ConstHoldout>> groups;
     for (auto &h : holdouts) {
@@ -209,6 +237,35 @@ int Arch::insertConstDrivers(const std::vector<ConstHoldout> &holdouts, std::vec
     int added = 0, seq = 0;
     for (auto &g : groups) {
         bool value = g.first.first != 0;
+        NetInfo *cnet = g.second.front().net;
+        // A wire an earlier pass already gave to a LUT of this constant takes
+        // its remaining users; anything else gets a new LUT.
+        std::vector<WireId> need_new;
+        std::vector<ConstHoldout> need_new_holdouts;
+        std::set<WireId> seen;
+        for (auto &h : g.second) {
+            WireId w = sink_wire(h);
+            const bool wire_already_seen = !seen.insert(w).second;
+            if (wire_already_seen)
+                continue;
+            NetInfo *bound = getBoundWireNet(w);
+            const bool wire_has_this_constant =
+                    bound != nullptr && bound != cnet && const_net_value(ctx, bound) == (value ? 1 : 0);
+            if (wire_has_this_constant) {
+                move_users(cnet, w, bound, " (wire already driven by it)");
+                continue;
+            }
+            need_new.push_back(w);
+        }
+        for (auto &h : g.second) {
+            const bool wire_needs_new_lut = std::find(need_new.begin(), need_new.end(), sink_wire(h)) != need_new.end();
+            if (wire_needs_new_lut)
+                need_new_holdouts.push_back(h);
+        }
+        const bool every_wire_already_driven = need_new.empty();
+        if (every_wire_already_driven)
+            continue;
+
         const char *base = value ? "$PACKER_VCC_NET" : "$PACKER_GND_NET";
         IdString cname, nname;
         while (true) {
@@ -234,26 +291,22 @@ int Arch::insertConstDrivers(const std::vector<ConstHoldout> &holdouts, std::vec
         nets[nname] = std::move(net);
         assignCellInfo(lut_ptr);
 
-        Loc origin = getBelLocation(g.second.front().cell->bel);
+        Loc origin = getBelLocation(need_new_holdouts.front().cell->bel);
         BelId bel = place_lut(lut_ptr, origin);
         const bool no_free_lut_bel = bel == BelId();
         if (no_free_lut_bel) {
             log_warning("    no free LUT bel within %d tiles of %s for a %s driver\n", max_radius,
-                        nameOfBel(g.second.front().cell->bel), value ? "VCC" : "GND");
+                        nameOfBel(need_new_holdouts.front().cell->bel), value ? "VCC" : "GND");
             disconnect_port(ctx, lut_ptr, id_O6);
             cells.erase(cname);
             nets.erase(nname);
-            for (auto &h : g.second)
+            for (auto &h : need_new_holdouts)
                 unplaced.push_back(h);
             continue;
         }
-        for (auto &h : g.second) {
-            disconnect_port(ctx, h.cell, h.port);
-            connect_port(ctx, net_ptr, h.cell, h.port);
-            assignCellInfo(h.cell);
-            log_info("    %s.%s <- %s (bel %s)\n", h.cell->name.c_str(ctx), h.port.c_str(ctx), cname.c_str(ctx),
-                     nameOfBel(bel));
-        }
+        std::string how = stringf(" (bel %s)", nameOfBel(bel));
+        for (WireId w : need_new)
+            move_users(cnet, w, net_ptr, how.c_str());
         added++;
     }
     return added;

--- a/xilinx/route_const.cc
+++ b/xilinx/route_const.cc
@@ -358,8 +358,9 @@ void Arch::routeConstants(std::function<void()> reroute)
         given_up_list.push_back(std::make_pair(h, why));
     };
     int drivers = 0, dont_care = 0, passes = 0;
+    std::vector<ConstHoldout> holdouts;
     for (int pass = 0;; pass++) {
-        auto holdouts = routeVcc();
+        holdouts = routeVcc();
         std::vector<ConstHoldout> real;
         for (auto &h : holdouts) {
             // Don't-cares first: a pin nothing selects is never an error.
@@ -423,6 +424,20 @@ void Arch::routeConstants(std::function<void()> reroute)
         log_info("Constant holdouts: %d local constant LUT(s) added, %d re-route pass(es), %d don't-care CARRY4 DI "
                  "pin(s) left unrouted\n",
                  drivers, passes, dont_care);
+    // Only report sinks the final fill still left unreached.
+    std::set<std::pair<IdString, IdString>> still_left;
+    for (auto &h : holdouts)
+        still_left.insert(std::make_pair(h.cell->name, h.port));
+    for (auto it = given_up_list.begin(); it != given_up_list.end();) {
+        const bool still_unreached = still_left.count(std::make_pair(it->first.cell->name, it->first.port)) != 0;
+        if (still_unreached) {
+            ++it;
+            continue;
+        }
+        log_info("    %s.%s reached by the final constant fill after all\n", it->first.cell->name.c_str(ctx),
+                 it->first.port.c_str(ctx));
+        it = given_up_list.erase(it);
+    }
     const bool have_leftovers = !given_up_list.empty();
     if (have_leftovers)
         report(given_up_list);


### PR DESCRIPTION
This fixes issue https://github.com/openXC7/nextpnr-xilinx/issues/180 seen when running a litex design on an xc7a100.

Constant nets are now always routed, or an error is returned, unless --allow-const-holdouts (or NEXTPNR_ALLOW_CONST_HOLDOUTS=1) is set.

Verified on device, and by running a simulation with the fasm2bels netlist before and after the fix.