### PR TITLE
xc7: fix SRL16E/SRLC32E INIT never reaching the bitstream

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -604,6 +604,45 @@ struct FasmBackend
                 lbound = (i == 1) ? 0 : 32;
                 ubound = (i == 1) ? 32 : 64;
             }
+            std::string orig_type = str_or_default(lut->attrs, ctx->id("X_ORIG_TYPE"), "");
+            if (orig_type == "SRL16E" || orig_type == "SRLC32E") {
+                // pack_srls() keeps the shift register's own (16- or 32-bit)
+                // INIT on the SLICE_LUTX cell it creates, but this cell has
+                // no logical LUT inputs to map through X_ORIG_PORT_* -- the
+                // phys_to_log walk below would leave every bit zero. Each
+                // SRL INIT bit k is stored in the LUT INIT at both bit 2k
+                // and 2k+1 (nextpnr-xilinx#181).
+                //
+                // For SRL16E specifically, pack.cc's pack_srls() ties A6
+                // (LUT address bit 5) to VCC when the cell is in the 6LUT
+                // position (i==0) -- so only addresses [32:64) are ever
+                // physically read, regardless of whether the sibling 5LUT
+                // half happens to also be populated. The lbound/ubound
+                // computed above only narrows to that when lut5 AND lut6
+                // are BOTH non-null, which is a different (fracturing)
+                // condition -- when the 5LUT half is genuinely unused
+                // (lut5 == nullptr, the common case), lbound/ubound stay at
+                // the full, un-narrowed [0:64) range, and the real bits get
+                // written to the address half A6 ties off (unreachable),
+                // leaving the actually-read half all zero. Confirmed on
+                // real hardware: without this override the SRL16E half of
+                // this fix reads back as 0 regardless of its INIT; with it,
+                // it reads correctly. SRLC32E never hits this: it only ties
+                // A1, using the full 64-bit space directly regardless of
+                // position, so it needs no override here.
+                if (orig_type == "SRL16E") {
+                    lbound = (i == 1) ? 0 : 32;
+                    ubound = (i == 1) ? 32 : 64;
+                }
+                int width = (ubound - lbound) / 2;
+                Property srl_init = get_or_default(lut->params, ctx->id("INIT"), Property()).extract(0, width);
+                for (int k = 0; k < width; k++) {
+                    bool bit = (srl_init.str.at(k) == Property::S1);
+                    bits[lbound + 2 * k] = bit;
+                    bits[lbound + 2 * k + 1] = bit;
+                }
+                continue;
+            }
             Property init = get_or_default(lut->params, ctx->id("INIT"), Property()).extract(0, 64);
             for (int j = lbound; j < ubound; j++) {
                 int log_index = 0;


### PR DESCRIPTION
Fixes #181.

`get_lut_init()` built every LUT's `INIT[63:0]` by mapping `X_ORIG_PORT_A1..A6` through the LUT's logical inputs. `pack_srls()`
gives an `SRL16E`/`SRLC32E` cell no logical LUT inputs, so that mapping always produced an all-zero vector -- every SRL powered up cleared regardless of its declared `INIT`, exactly as #181 describes.

## The fix has two parts

**Part 1**: when a LUT's `X_ORIG_TYPE` is `SRL16E` or `SRLC32E`, write its own `INIT` parameter directly instead of going through the logical-input mapping. Each SRL INIT bit `k` is stored in the LUT INIT at both bit `2k` and `2k+1` -- confirmed against a real Vivado bitstream decoded with `fasm2bels`, and by round-tripping our own generated bitstream back through the same tool.

**Part 2**, found only once part 1 was checked on real hardware: an `SRL16E` in the 6LUT position (as opposed to 5LUT) has `pack.cc`'s `pack_srls()` tie `A6` (LUT address bit 5) to VCC -- so only LUT addresses `[32:64)` are ever physically read, regardless of whether the sibling 5LUT half happens to also be populated. Naively reusing this function's existing `lbound`/`ubound` (which only narrows to a half when `lut5` AND `lut6` are BOTH non-null -- an unrelated fracturing
condition) left the full, un-narrowed `[0:64)` range in the common case where the 5LUT half is genuinely unused, silently writing the real bits to the address half `A6` ties off. This was bit-perfect in the FASM and round-tripped correctly by `fasm2bels` regardless -- the bitstream just wasn't asking the real hardware to read from the address it wrote to, which is why it wasn't caught by static/tool-based verification alone. `SRLC32E` never hits this: it only ties `A1`, uses the full 64-bit space directly regardless of position, and needs no override.

## Testing

Verified on real hardware (Arty S7-25, `xc7s25csga324-1`): an `SRL16E` and an `SRLC32E`, each with a non-trivial `INIT` and `CE`/`D` tied off so the register can never shift, tapped at an address whose `INIT` bit is `1` and read out combinationally to an LED.

- Before this fix: `SRL16E` read `0` (matching the original bug). - After fixing part 1 alone: `SRLC32E` read correctly, but `SRL16E` still read `0` -- part 2's bug, previously masked because #181's own reproducer happens to tap an address whose real INIT bit is `0` either way, so it didn't expose this. - After both parts: both read correctly.

Also confirmed via `fasm2bels` round-trip decode that the recovered netlist's `SRL16E`/`SRLC32E` `INIT` parameters exactly match the original RTL (`16'h5A3C`, `32'h0F1E2D3C`) in both cases.