### PR TITLE
xc7: enforce WEMUX consistency across a SLICEM half-tile

### DIFF
--- a/xilinx/arch_place.cc
+++ b/xilinx/arch_place.cc
@@ -931,6 +931,34 @@ bool Arch::xc7_logic_tile_valid(IdString tileType, LogicTileStatus &lts) const
                     }
                 }
             }
+            // The WEMUX driving the SRL/DRAM WE pin is shared across the
+            // bottom half of a SLICEM, so all memory/SRL cells in that
+            // half-tile must agree on the WE net.  Without this check, two
+            // SRLs/DRAMs from independent write-enable domains can both be
+            // placed into the same SLICEM half and then fail routing on
+            // SITEWIRE/SLICE_*/WEMUX_OUT (ported from gatecat/nextpnr-xilinx#98).
+            if (i == 0) {
+                NetInfo *we = nullptr;
+                for (int z = 4 * i; z < 4 * (i + 1); z++) {
+                    for (int k = 0; k < 2; k++) {
+                        CellInfo *lut = lts.cells[z << 4 | (BEL_6LUT + k)];
+                        if (lut == nullptr)
+                            continue;
+                        if (!lut->lutInfo.is_memory && !lut->lutInfo.is_srl)
+                            continue;
+                        if (lut->lutInfo.we == nullptr)
+                            continue;
+                        if (we == nullptr) {
+                            we = lut->lutInfo.we;
+                        } else if (we != lut->lutInfo.we) {
+                            if (dbg_validity_runtime)
+                                log_info("  invalid-arm: half-tile WE mismatch: %s vs %s\n", nameOf(we),
+                                         nameOf(lut->lutInfo.we));
+                            return false;
+                        }
+                    }
+                }
+            }
             NetInfo *clk = nullptr, *sr = nullptr, *ce = nullptr;
             bool clkinv = false, srinv = false, islatch = false, ffsync = false;
             for (int z = 4 * i; z < 4 * (i + 1); z++) {

--- a/xilinx/arch_place.cc
+++ b/xilinx/arch_place.cc
@@ -942,15 +942,20 @@ bool Arch::xc7_logic_tile_valid(IdString tileType, LogicTileStatus &lts) const
                 for (int z = 4 * i; z < 4 * (i + 1); z++) {
                     for (int k = 0; k < 2; k++) {
                         CellInfo *lut = lts.cells[z << 4 | (BEL_6LUT + k)];
-                        if (lut == nullptr)
+                        bool lut_is_absent = lut == nullptr;
+                        if (lut_is_absent)
                             continue;
-                        if (!lut->lutInfo.is_memory && !lut->lutInfo.is_srl)
+                        bool lut_is_not_memory_or_srl = !lut->lutInfo.is_memory && !lut->lutInfo.is_srl;
+                        if (lut_is_not_memory_or_srl)
                             continue;
-                        if (lut->lutInfo.we == nullptr)
+                        bool lut_has_no_we = lut->lutInfo.we == nullptr;
+                        if (lut_has_no_we)
                             continue;
-                        if (we == nullptr) {
+                        bool we_not_yet_recorded = we == nullptr;
+                        bool we_disagrees_with_recorded = we != lut->lutInfo.we;
+                        if (we_not_yet_recorded) {
                             we = lut->lutInfo.we;
-                        } else if (we != lut->lutInfo.we) {
+                        } else if (we_disagrees_with_recorded) {
                             if (dbg_validity_runtime)
                                 log_info("  invalid-arm: half-tile WE mismatch: %s vs %s\n", nameOf(we),
                                          nameOf(lut->lutInfo.we));

--- a/xilinx/archdefs.h
+++ b/xilinx/archdefs.h
@@ -173,7 +173,7 @@ struct ArchCellInfo
             bool only_drives_carry;
             NetInfo *input_sigs[6], *output_sigs[2];
             NetInfo *address_msb[3];
-            NetInfo *di1_net, *di2_net, *wclk;
+            NetInfo *di1_net, *di2_net, *wclk, *we;
         } lutInfo;
         struct
         {

--- a/xilinx/pack.cc
+++ b/xilinx/pack.cc
@@ -1535,6 +1535,7 @@ void Arch::assignCellInfo(CellInfo *cell)
         cell->lutInfo.di1_net = get_net_or_empty(cell, id_DI1);
         cell->lutInfo.di2_net = get_net_or_empty(cell, id_DI2);
         cell->lutInfo.wclk = get_net_or_empty(cell, id_CLK);
+        cell->lutInfo.we = get_net_or_empty(cell, id_WE);
         cell->lutInfo.memory_group = 0; // fixme
         cell->lutInfo.is_srl = cell->attrs.count(id("X_LUT_AS_SRL"));
         cell->lutInfo.is_memory = cell->attrs.count(id("X_LUT_AS_DRAM"));


### PR DESCRIPTION
## Summary

The WEMUX driving the SRL/DRAM WE pin is shared across all four LUT positions of a SLICEM's memory-capable half-tile, so two SRL/DRAM cells from independent write-enable domains cannot legally share a half-tile. Today the placer happily co-places them and the router then fails with an overused `SITEWIRE/SLICE_*/WEMUX_OUT` wire — a build-time failure with no earlier, clearer diagnostic.

This adds a WE agreement check to `xc7_logic_tile_valid()`'s half-tile loop, mirroring the existing `wclk` check already in the same function: each memory/SRL LUT's WE net is stored on `lutInfo` in `assignCellInfo()`, and the placement is rejected outright if two such cells in the same half-tile disagree on their WE net — giving the placer a chance to legalize elsewhere instead of letting an illegal placement reach the router.

Ported from [gatecat/nextpnr-xilinx#98](https://github.com/gatecat/nextpnr-xilinx/pull/98) — verified the described mechanism directly against that repo's actual current source (the analogous `wclk` collection pattern, `lutInfo` struct, `assignCellInfo()`) before porting the equivalent change here.

## Verification

Built a repro: 80x `SRL16E`, split across two independent WE domains (two distinct button inputs, so genuinely different nets rather than something synthesis could fold together), with no explicit placement constraints (deliberately, since this test is about the *placer's own* natural tendency to co-place unrelated small cells under some seeds, not a forced pathological case).

| | 10 seeds, without this fix | 10 seeds, with this fix |
|---|---|---|
| Result | **10/10 fail** to route: `overused wire SITEWIRE/SLICE_X*Y*/WEMUX_OUT (2 nets)` | **10/10 route cleanly**, zero WEMUX conflicts |

With the fix, built the resulting bitstream and flashed it to real hardware (Arty S7-25): confirmed correct readback of the placed/routed design.

## Test plan

- [x] Build before/after this patch; confirm the WEMUX-conflict repro fails 10/10 seeds without it and succeeds 10/10 with it.
- [x] Flash the resulting (fixed) bitstream to hardware; confirm correct SRL readback.
- [x] No behavior change for designs without independent-WE-domain memory/SRL cells sharing a half-tile (this is a pure additional validity check, only rejects placements that were already going to fail at routing).