### PR TITLE
xc7: disconnect constant-tied STARTUPE2 control pins instead of routing them

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -1963,7 +1963,14 @@ struct FasmBackend
                 if (prog_usr != "TRUE" && prog_usr != "FALSE")
                     log_error("Invalid PROG_USR attribute in STARTUPE2 of '%s\n'. Allowed values are: TRUE, FALSE.", prog_usr.c_str());
                 write_bit("STARTUP.PROG_USR", prog_usr == "TRUE");
-                write_bit("STARTUP.USRCCLKO_CONNECTED", !net_is_constant(get_net_or_empty(ci, ctx->id("USRCCLKO"))));
+                // A constant-tied USRCCLKO is now disconnected entirely by pack_cfg()
+                // (nullptr net) rather than left wired to $PACKER_GND_NET/_VCC_NET, so
+                // net_is_constant(nullptr) -- which returns false -- can no longer be
+                // used to detect "not really connected" here. Treat "no net at all"
+                // the same as "constant": only a genuine dynamic net counts as connected.
+                NetInfo *usrcclko_net = get_net_or_empty(ci, ctx->id("USRCCLKO"));
+                bool usrcclko_connected = usrcclko_net != nullptr && !net_is_constant(usrcclko_net);
+                write_bit("STARTUP.USRCCLKO_CONNECTED", usrcclko_connected);
             }
 
             pop();

--- a/xilinx/pack_io_xc7.cc
+++ b/xilinx/pack_io_xc7.cc
@@ -1266,6 +1266,47 @@ void XC7Packer::pack_cfg()
             preplace_unique(ci);
         }
     }
+
+    // STARTUPE2's control pins (GSR/GTS/KEYCLEARB/PACK/USRCCLKO/USRCCLKTS/
+    // USRDONEO/USRDONETS/CLK) are commonly tied to a constant when unused
+    // (e.g. GTS/KEYCLEARB/PACK left at '0). Routing $PACKER_GND_NET/
+    // $PACKER_VCC_NET into them via the general-fabric BFS (the same
+    // mechanism already found to misbehave for BUFHCE's CE pin and CARRY4's
+    // PRECYINIT) writes ~40 bits into CFG_CENTER_MID that don't correspond to
+    // any documented feature in prjxray's segbits database at all, and a
+    // hardware A/B test against an equivalent Vivado-implemented design
+    // showed those bits present only on the nextpnr side (nextpnr-xilinx#177
+    // GSR investigation) -- Vivado's own bitstream has all-zero frames for
+    // this tile's constant-tied pins, i.e. it simply leaves them unrouted.
+    // Match that: disconnect any STARTUP_STARTUP control pin driven by a
+    // constant net instead of letting the router bridge it through general
+    // interconnect.
+    {
+        IdString gnd = ctx->id("$PACKER_GND_NET");
+        IdString vcc = ctx->id("$PACKER_VCC_NET");
+        static const std::vector<std::string> startup_const_pins = {
+            "GSR", "GTS", "KEYCLEARB", "PACK", "USRCCLKO",
+            "USRCCLKTS", "USRDONEO", "USRDONETS", "CLK"
+        };
+        int nfix = 0;
+        for (auto cell : sorted(ctx->cells)) {
+            CellInfo *ci = cell.second;
+            if (ci->type != id_STARTUP_STARTUP)
+                continue;
+            for (const auto &pin : startup_const_pins) {
+                IdString port = ctx->id(pin);
+                NetInfo *net = get_net_or_empty(ci, port);
+                bool is_const = net != nullptr && (net->name == gnd || net->name == vcc);
+                if (is_const) {
+                    disconnect_port(ctx, ci, port);
+                    ++nfix;
+                }
+            }
+        }
+        if (nfix > 0)
+            log_info("    disconnected %d constant-tied STARTUPE2 control pin(s) "
+                      "(left unrouted, matching Vivado's own convention)\n", nfix);
+    }
 }
 
 NEXTPNR_NAMESPACE_END


### PR DESCRIPTION
## Summary
- `STARTUPE2`'s control pins (`GSR`/`GTS`/`KEYCLEARB`/`PACK`/`USRCCLKO`/`USRCCLKTS`/`USRDONEO`/`USRDONETS`/`CLK`) are commonly tied to a constant when unused. Routing `$PACKER_GND_NET`/`$PACKER_VCC_NET` into them via the general-fabric BFS router — the same mechanism already found to misbehave for BUFHCE's `CE` pin (#177, PR #187) and `CARRY4`'s `PRECYINIT` — writes ~40 bits into `CFG_CENTER_MID` that don't correspond to any documented feature in prjxray's segbits database at all.
- Found via a hardware A/B test in the #177 GSR investigation: built an identical design (`STARTUPE2` with `GSR` driven by a button) through both nextpnr and a real Vivado flow. Vivado's implementation correctly resets a test flip-flop on `GSR` assertion; nextpnr's does not. Diffing the raw per-bit frame data for `CFG_CENTER_MID` (bypassing `bit2fasm`/segbits naming, which was independently found to have decode gaps elsewhere) showed Vivado's bitstream has all-zero frames for this tile's constant-tied pins — it simply leaves them unrouted — while nextpnr's had ~40 spurious, undocumented bits set.
- Disconnects any `STARTUP_STARTUP` control pin driven by a constant net in `pack_cfg()`, matching Vivado's own convention. This removes 28 of the ~40 mystery bits (confirmed via a before/after raw-bit diff); the remaining ~12 are tied to `GSR`'s own real, necessary routing and are a separate, narrower open question (undocumented `CFG_CENTER_MID` pips, not a constant-tie issue) — `GSR` still does not reset FFs after this fix, so this is a real but partial improvement, not a full resolution of the GSR issue.
- Also fixes a latent bug this change would otherwise introduce: `USRCCLKO_CONNECTED` was computed as `!net_is_constant(net)`, which returns `true` for a `nullptr` net (no net at all) since `net_is_constant()` only recognizes `$PACKER_GND_NET`/`$PACKER_VCC_NET` as "constant". Once a constant-tied `USRCCLKO` is disconnected (net becomes `nullptr`) that computation would incorrectly flip to "connected". Explicitly requires a non-null net now.

## Test plan
- [x] Verified no regression: a design with no `STARTUPE2` instance cannot enter the `STARTUP_STARTUP`-gated code path (compile-time-provable from the `ci->type` guard), and a bit-for-bit FASM diff against the existing #177 reference build confirms zero difference.
- [x] Confirmed on real hardware (Arty S7-25): before the fix, `~40` undocumented bits set in `CFG_CENTER_MID`'s frames, live GSR press has zero effect on a test flip-flop. After the fix, `28` of those bits are gone (verified via raw `bitread` diff, not `bit2fasm`, since that decoder has independently-confirmed gaps elsewhere), but GSR still does not reset the FF — the remaining ~12 bits (tied to GSR's own real routing) are a separate, still-open issue.
- [x] Confirmed the fix's own FASM output is stable (identical) when rebased onto latest `main`.

Full diagnostic history is in [nextpnr-xilinx#177](https://github.com/openXC7/nextpnr-xilinx/issues/177) (the GSR-investigation comments).