### PR TITLE
xc7: fix MMCM/PLL LOCKED never asserting (PWRDWN invert, RST invert, PHASE default)

### DIFF
--- a/xilinx/fasm.cc
+++ b/xilinx/fasm.cc
@@ -2509,7 +2509,13 @@ struct FasmBackend
         int high = 1, low = 1, phasemux = 0, delaytime = 0, frac = 0;
         bool no_count = false, edge = false;
         double divide = float_or_default(ci, name + ((name == "CLKFBOUT") ? "_MULT" : "_DIVIDE"), 1);
-        double phase = float_or_default(ci, name + "_PHASE", 1);
+        // Xilinx's documented default for CLKOUT<n>_PHASE/CLKFBOUT_PHASE is 0.0
+        // degrees (UG472) -- defaulting to 1 here computed a spurious non-zero
+        // PHASE_MUX bit for any counter whose PHASE param the source netlist
+        // doesn't set explicitly (e.g. CLKFBOUT, when only CLKOUT0 has an
+        // explicit PHASE), found via a raw-bit diff against a real Vivado
+        // MMCM bitstream (nextpnr-xilinx#177 MMCM-lock investigation).
+        double phase = float_or_default(ci, name + "_PHASE", 0);
         if (divide <= 1) {
             no_count = true;
         } else {
@@ -2763,7 +2769,13 @@ struct FasmBackend
         bool no_count = false, edge = false;
         double divide = float_or_default(ci, name + ((name == "CLKFBOUT") ? "_MULT_F" :
                                                      (name == "CLKOUT0" ? "_DIVIDE_F" : "_DIVIDE")), 1);
-        double phase = float_or_default(ci, name + "_PHASE", 1);
+        // Xilinx's documented default for CLKOUT<n>_PHASE/CLKFBOUT_PHASE is 0.0
+        // degrees (UG472) -- defaulting to 1 here computed a spurious non-zero
+        // PHASE_MUX bit for any counter whose PHASE param the source netlist
+        // doesn't set explicitly (e.g. CLKFBOUT, when only CLKOUT0 has an
+        // explicit PHASE), found via a raw-bit diff against a real Vivado
+        // MMCM bitstream (nextpnr-xilinx#177 MMCM-lock investigation).
+        double phase = float_or_default(ci, name + "_PHASE", 0);
         if (divide <= 1) {
             no_count = true;
         } else {

--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -228,6 +228,18 @@ void XC7Packer::pack_plls()
                 if (nn != nullptr && (nn->name == gnd || nn->name == vcc)) {
                     disconnect_port(ctx, ci, ctx->id(p));
                     ++n;
+                    // Once PWRDWN is left unrouted (matching Vivado), the site's own
+                    // floating default reads as asserted (powered down) unless
+                    // IS_PWRDWN_INVERTED is set -- confirmed via a raw-bit diff
+                    // against a real Vivado MMCM bitstream (nextpnr-xilinx#177 MMCM
+                    // lock investigation): Vivado sets ZINV_PWRDWN on this exact
+                    // disconnect for a GND-tied (i.e. "don't power down") PWRDWN.
+                    // Only apply this for the GND-tied case; a VCC-tied PWRDWN
+                    // explicitly asked to be powered down and disconnecting it
+                    // shouldn't also flip that intent.
+                    bool pwrdwn_wanted_off = p == "PWRDWN" && nn->name == gnd;
+                    if (pwrdwn_wanted_off)
+                        ci->params[ctx->id("IS_PWRDWN_INVERTED")] = Property(1);
                 }
             }
             if (is_mmcm) {

--- a/xilinx/pack_clocking_xc7.cc
+++ b/xilinx/pack_clocking_xc7.cc
@@ -248,6 +248,14 @@ void XC7Packer::pack_plls()
                     if (nn != nullptr && (nn->name == gnd || nn->name == vcc)) {
                         disconnect_port(ctx, ci, ctx->id(p));
                         ++n;
+                        // Same mechanism as the PWRDWN fix above: a disconnected
+                        // GND-tied RST reads as asserted on the site's own floating
+                        // default unless IS_RST_INVERTED is set -- confirmed via
+                        // the same raw-bit diff against a real Vivado MMCM
+                        // bitstream (nextpnr-xilinx#177).
+                        bool rst_wanted_off = p == "RST" && nn->name == gnd;
+                        if (rst_wanted_off)
+                            ci->params[ctx->id("IS_RST_INVERTED")] = Property(1);
                     }
                 }
             }


### PR DESCRIPTION
## Summary
Fixes `MMCME2_BASE`/`MMCME2_ADV` (and the equivalent `PLLE2_ADV` code path) never asserting `LOCKED` in this toolchain, found during the #177 investigation. Three small, well-understood fixes, found via a full raw-bit diff against a real Vivado MMCM bitstream:

1. **`ZINV_PWRDWN`**: `pack_plls()` already disconnects a constant-tied `PWRDWN` pin to match Vivado's "leave unrouted" convention, but didn't set the matching `IS_PWRDWN_INVERTED` param. Without it, the site's floating default for a disconnected `PWRDWN` reads as asserted, permanently powering down the MMCM. Fixed for the GND-tied ("don't power down") case specifically.
2. **`ZINV_RST`**: same mechanism, same fix, for `RST` (also disconnected as a constant-tied pin by the same code path).
3. **`PHASE` default**: `write_mmcm_clkout()`/`write_pll_clkout()` defaulted a counter's `PHASE` parameter to `1` (degree) when the source netlist doesn't set it explicitly. Xilinx's documented default (UG472) is `0.0` degrees -- the stray `1` computed a spurious non-zero `PHASE_MUX` bit for any counter without an explicit `PHASE` param (e.g. `CLKFBOUT`, when only `CLKOUT0` sets one explicitly).

With all three fixes, a full decoded-FASM diff against a real Vivado reference for this exact MMCM configuration (`DIVCLK_DIVIDE=1`, `CLKFBOUT_MULT_F=60`, `CLKOUT0_DIVIDE_F=60`) is byte-for-byte identical -- no remaining differences at all.

(Also fixed along the way, still included: an initial ~80-bit-looking gap turned out to mostly be the codebase's own pre-existing, correct "unused CLKOUT counter" default-writing logic, which a stale locally-built test binary hadn't picked up -- once rebuilt fresh, the real remaining gap was exactly these two bits.)

## Scope note
This fixes `LOCKED` itself, confirmed both by an exact bitstream match against Vivado and by a direct hardware read of the `LOCKED` output pin. It does **not** by itself resolve #177's main BUFHCE mystery -- a downstream flip-flop clocked from this MMCM's output, if it lands on the known-broken `BUFHCE_X0Y0` site (nextpnr's default/natural placement for logic near this issue's test pin), still won't see a clock edge, exactly as documented elsewhere in #177. This PR unblocks MMCM-sourced clock topologies in general and enables a direct hardware test of the community's BUFH/BUFHCE naming-mismatch theory (#189), which was previously impossible without a working `LOCKED`.

## Test plan
- [x] Confirmed the MMCM parameters themselves are valid: built the identical design through real Vivado -- it locks and runs correctly on the same site (`MMCME2_ADV_X0Y1`).
- [x] Confirmed via a decoded-FASM diff (`bit2fasm`) that nextpnr's output for this MMCM configuration is now byte-for-byte identical to Vivado's own bitstream.
- [x] Hardware-tested on Arty S7-25: `LOCKED` now asserts (read directly on an LED), confirmed reproducible.
- [x] Verified no regression: the bare BUFHCE-passthrough repro from #177 (which uses no MMCM/PLL at all) is provably unaffected, since all three fixes are gated on `is_pll`/`is_mmcm`/the `write_mmcm_clkout`/`write_pll_clkout` code path.